### PR TITLE
Corrected the way how temp directory is created

### DIFF
--- a/prophyc/calc.py
+++ b/prophyc/calc.py
@@ -3,10 +3,7 @@ import ply.lex as lex
 import ply.yacc as yacc
 import os
 
-PROPHY_DIR = os.path.join(tempfile.gettempdir(), '.prophy')
-
-if not os.path.exists(PROPHY_DIR):
-    os.makedirs(PROPHY_DIR)
+PROPHY_DIR = tempfile.mkdtemp('.prophy')
 
 class ParseError(Exception): pass
 

--- a/prophyc/parsers/prophy.py
+++ b/prophyc/parsers/prophy.py
@@ -8,10 +8,7 @@ from prophyc.six import ifilter
 from prophyc.model import Include, Constant, Typedef, Enum, EnumMember, Struct, StructMember, Union, UnionMember, Kind, ParseError
 from prophyc.file_processor import CyclicIncludeError, FileNotFoundError
 
-PROPHY_DIR = os.path.join(tempfile.gettempdir(), '.prophy')
-
-if not os.path.exists(PROPHY_DIR):
-    os.makedirs(PROPHY_DIR)
+PROPHY_DIR = tempfile.mkdtemp('.prophy')
 
 def get_column(input, pos):
     return pos - input.rfind('\n', 0, pos)


### PR DESCRIPTION
Solution uses tempfile.mkdtemp, to safely create this directory, even in
high concurrent environment, to avoid errors like this:

```
Traceback (most recent call last):
...
  File ".../site-packages/prophyc/calc.py", line 9, in
<module>
    os.makedirs(PROPHY_DIR)
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '/tmp/.prophy'
```
