### PR TITLE
Allow negative values for enum in ISAR

### DIFF
--- a/prophyc/model.py
+++ b/prophyc/model.py
@@ -64,8 +64,6 @@ class EnumMember(object):
 
     def __init__(self, name, value):
         self.name = name
-        if "EOaMDeltaFPucchF3r10_DeltaFMinus10" in name:
-            raise Exception
         self.value = value
 
     def __eq__(self, other):

--- a/prophyc/model.py
+++ b/prophyc/model.py
@@ -64,6 +64,8 @@ class EnumMember(object):
 
     def __init__(self, name, value):
         self.name = name
+        if "EOaMDeltaFPucchF3r10_DeltaFMinus10" in name:
+            raise Exception
         self.value = value
 
     def __eq__(self, other):

--- a/prophyc/parsers/isar.py
+++ b/prophyc/parsers/isar.py
@@ -72,25 +72,27 @@ def make_typedef(elem):
     elif "primitiveType" in elem.attrib and elem.get("name") not in primitive_types.values():
         return model.Typedef(elem.get("name"), primitive_types[elem.get("primitiveType")])
 
-def make_enum_member(elem, warn):
+def make_enum_member(elem):
     value = elem.get('value')
     try:
         int_value = int(value, 0)
         if int_value < 0:
             value = "0x{:X}".format(0x100000000 + int_value)
-    except ValueError as e:
-        if warn:
-            warn(str(e))
+    except ValueError:
+        pass
     return model.EnumMember(elem.get("name"), expand_operators(value))
 
-def make_enum(elem, warn):
+def _check_for_duplicates(enum):
+    values = set()
+    for m in enum.members:
+        if m.value in values:
+            raise ValueError("Duplicate Enum value in '{}', value '{}'.".format(enum.name, m.value))
+        values.add(m.value)
+
+def make_enum(elem):
     if len(elem):
-        values = set()
-        enum = model.Enum(elem.get("name"), [make_enum_member(member, warn) for member in elem])
-        for m in enum.members:
-            if m.value in values:
-                raise ValueError("Duplicate Enum value in '{}', value '{}'.".format(enum.name, m.value))
-            values.add(m.value)
+        enum = model.Enum(elem.get("name"), [make_enum_member(member) for member in elem])
+        _check_for_duplicates(enum)
         return enum
 
 def make_struct_members(elem, dynamic_array = False):
@@ -148,7 +150,7 @@ class IsarParser(object):
         nodes += [make_include(elem, process_file, self.warn) for elem in filter(lambda elem: "include" in elem.tag, root.iterfind('.//*[@href]'))]
         nodes += [make_constant(elem) for elem in root.iterfind('.//constant')]
         nodes += filter(None, (make_typedef(elem) for elem in root.iterfind('.//typedef')))
-        nodes += filter(None, (make_enum(elem, self.warn) for elem in root.iterfind('.//enum')))
+        nodes += filter(None, (make_enum(elem) for elem in root.iterfind('.//enum')))
         nodes += filter(None, (make_struct(elem) for elem in root.iterfind('.//struct')))
         nodes += filter(None, (make_union(elem) for elem in root.iterfind('.//union')))
         nodes += filter(None, (make_struct(elem, last_member_array_is_dynamic = True) for elem in root.iterfind('.//message')))

--- a/prophyc/tests/parsers/test_isar.py
+++ b/prophyc/tests/parsers/test_isar.py
@@ -1,3 +1,5 @@
+import pytest
+
 from prophyc import model
 from prophyc.parsers.isar import IsarParser
 from prophyc.parsers.isar import expand_operators
@@ -132,6 +134,7 @@ def test_enums_parsing():
         <enum-member name="EEnum_A" value="0"/>
         <enum-member name="EEnum_B" value="1"/>
         <enum-member name="EEnum_C" value="-1"/>
+        <enum-member name="EEnum_D" value="-10"/>
     </enum>
 </x>
 """
@@ -140,8 +143,24 @@ def test_enums_parsing():
             model.EnumMember("EEnum_A", "0"),
             model.EnumMember("EEnum_B", "1"),
             model.EnumMember("EEnum_C", "0xFFFFFFFF"),
+            model.EnumMember("EEnum_D", "0xFFFFFFF6"),
         ])
     ]
+
+def test_enums_parsing_repeated_value():
+    xml = """\
+<x>
+    <enum name="EEnum">
+        <enum-member name="EEnum_D" value="-10"/>
+        <enum-member name="EEnum_D2" value="0xFFFFFFF6"/>
+    </enum>
+</x>
+"""
+    with pytest.raises(ValueError) as e:
+        parse(xml)
+    assert "Duplicate Enum value" in str(e)
+
+
 
 def test_struct_parsing():
     xml = """\

--- a/prophyc/tests/parsers/test_isar.py
+++ b/prophyc/tests/parsers/test_isar.py
@@ -534,3 +534,4 @@ def test_operator_expansion_in_enum_and_constant():
             model.EnumMember("Enum_A", "((Constant) << (16))")
         ])
     )]
+    assert nodes[1].members[0].value == "((Constant) << (16))"

--- a/prophyc/tests/parsers/test_isar.py
+++ b/prophyc/tests/parsers/test_isar.py
@@ -160,8 +160,6 @@ def test_enums_parsing_repeated_value():
         parse(xml)
     assert "Duplicate Enum value" in str(e)
 
-
-
 def test_struct_parsing():
     xml = """\
 <x>


### PR DESCRIPTION
Feature will work as it already is implemented for Sack: negative values are stored as positive.

Exception will be thrown if as a result the same value will be used twice.