### PR TITLE
improved sack supplementation

### DIFF
--- a/prophyc/__init__.py
+++ b/prophyc/__init__.py
@@ -82,7 +82,7 @@ def get_target_parser(emit, opts, supplementary_nodes):
         status = SackParser.check()
         if not status:
             emit.error(status.error)
-        return SackParser(opts.include_dirs, warn=emit.warn, supple_nodes=supplementary_nodes)
+        return SackParser(opts.include_dirs, warn=emit.warn, include_tree=supplementary_nodes)
     else:
         from prophyc.parsers.prophy import ProphyParser
         return ProphyParser()

--- a/prophyc/parsers/sack.py
+++ b/prophyc/parsers/sack.py
@@ -4,45 +4,38 @@ import ctypes.util
 from .clang.cindex import Config, Index, CursorKind, TypeKind, TranslationUnitLoadError, LibclangError
 
 from prophyc import model
-
-unambiguous_builtins = {
-    TypeKind.UCHAR: 'u8',
-    TypeKind.SCHAR: 'i8',
-    TypeKind.CHAR_S: 'i8',
-    TypeKind.POINTER: 'u32',
-    TypeKind.FLOAT: 'r32',
-    TypeKind.DOUBLE: 'r64',
-    TypeKind.BOOL: 'i32'
-}
+from prophyc.generators.cpp import _generate_def_enum
+from contextlib import contextmanager
 
 class SackParserError(Exception):
     pass
 
-class SackModel(object):
-    def __init__(self, included_isar_supples=[]):
+class SackModelTree(object):
+    def __init__(self):
         self.known = set()
         self.nodes = []
-        list(map(self.add_node, included_isar_supples))
-        self.names_defined_in_isar = list(SackModel.get_node_names(included_isar_supples))
 
     def add_node(self, node):
         self.known.add(node.name)
         self.nodes.append(node)
 
-    @staticmethod
-    def get_node_names(nodes_list):
-        for node in nodes_list:
-            if isinstance(node, model.Include):
-                for name in SackModel.get_node_names(node.nodes):
-                    yield name
-            else:
-                yield node.name
+    def remove_nodes(self, node_names_to_remove):
+        self.nodes = [node for node in self.nodes if node.name not in node_names_to_remove]
+        self.known -= set(node_names_to_remove)
 
 class Builder(object):
+    unambiguous_builtins = {
+        TypeKind.UCHAR: 'u8',
+        TypeKind.SCHAR: 'i8',
+        TypeKind.CHAR_S: 'i8',
+        TypeKind.POINTER: 'u32',
+        TypeKind.FLOAT: 'r32',
+        TypeKind.DOUBLE: 'r64',
+        TypeKind.BOOL: 'i32'
+    }
 
-    def __init__(self, tree_model, parsed_file_content):
+    def __init__(self, tree_model):
         self.tree = tree_model
-        self.content = parsed_file_content
 
     @staticmethod
     def alphanumeric_name(cursor):
@@ -55,13 +48,7 @@ class Builder(object):
             name = name.replace('union ', '', 1)
         return re.sub('[^0-9a-zA-Z_]+', '__', name)
 
-    def get_type_name_of_missing_declaration(self, cursor):
-        spelling = cursor.spelling
-        spelling_len = len(spelling) if spelling else 0
-        decl_start, decl_end = cursor.extent.start.offset, cursor.extent.end.offset
-        return self.content[decl_start:decl_end - spelling_len].decode().strip()
-
-    def get_type_name(self, tp, cursor):
+    def get_type_name(self, tp):
         decl = tp.get_declaration()
 
         def dive_deeper(method):
@@ -71,7 +58,8 @@ class Builder(object):
             return name
 
         if tp.kind is TypeKind.TYPEDEF:
-            return self.get_type_name(decl.underlying_typedef_type, cursor)
+            return self.get_type_name(decl.underlying_typedef_type)
+
         elif tp.kind in (TypeKind.UNEXPOSED, TypeKind.ELABORATED, TypeKind.RECORD):
 
             if decl.kind in (CursorKind.STRUCT_DECL, CursorKind.CLASS_DECL):
@@ -81,32 +69,29 @@ class Builder(object):
                 return dive_deeper(self.add_union)
 
             elif decl.kind is CursorKind.ENUM_DECL:
-                return self.get_type_name(decl.type, cursor)
+                return self.get_type_name(decl.type)
 
             elif decl.kind is CursorKind.TYPEDEF_DECL:
-                return self.get_type_name(decl.underlying_typedef_type, cursor)
+                return self.get_type_name(decl.underlying_typedef_type)
 
             else:
-                raise SackParserError("Unknown declaration")
+                raise SackParserError("Unknown declaration, {} {}".format(tp.spelling, decl.kind))
 
         elif tp.kind in (TypeKind.CONSTANTARRAY, TypeKind.INCOMPLETEARRAY):
-            return self.get_type_name(tp.element_type, cursor)
+            return self.get_type_name(tp.element_type)
 
         elif tp.kind is TypeKind.ENUM:
             return dive_deeper(self.add_enum)
-
-        if decl.kind is CursorKind.NO_DECL_FOUND and cursor:
-            name = self.get_type_name_of_missing_declaration(cursor)
-            if name in self.tree.names_defined_in_isar:
-                return name
 
         if tp.kind in (TypeKind.USHORT, TypeKind.UINT, TypeKind.ULONG, TypeKind.ULONGLONG):
             return 'u%d' % (tp.get_size() * 8)
 
         elif tp.kind in (TypeKind.SHORT, TypeKind.INT, TypeKind.LONG, TypeKind.LONGLONG):
             return 'i%d' % (tp.get_size() * 8)
-
-        return unambiguous_builtins[tp.kind]
+        try:
+            return self.unambiguous_builtins[tp.kind]
+        except KeyError as e:
+            raise SackParserError("Unknown declaration, {} {} {}".format(tp.spelling, decl.kind, e))
 
     def add_enum(self, cursor):
         def enum_member(cursor):
@@ -130,7 +115,7 @@ class Builder(object):
 
         def struct_member(cursor_):
             name = cursor_.spelling.decode()
-            type_name = self.get_type_name(cursor_.type, cursor_)
+            type_name = self.get_type_name(cursor_.type)
             array_len = array_length(cursor_.type)
             return model.StructMember(name, type_name, size=array_len)
 
@@ -142,7 +127,7 @@ class Builder(object):
     def add_union(self, cursor):
         def union_member(cursor, disc):
             name = cursor.spelling.decode()
-            type_name = self.get_type_name(cursor.type, cursor)
+            type_name = self.get_type_name(cursor.type)
             return model.UnionMember(name, type_name, str(disc))
 
         members = [union_member(x, i) for i, x in enumerate(cursor.get_children())
@@ -150,18 +135,76 @@ class Builder(object):
         node = model.Union(Builder.alphanumeric_name(cursor), members)
         self.tree.add_node(node)
 
-def build_model(tu, tree, content):
-    builder = Builder(tree, content)
-    for cursor in tu.cursor.get_children():
-        if cursor.kind is CursorKind.UNEXPOSED_DECL:
-            for in_cursor in cursor.get_children():
-                if in_cursor.kind is CursorKind.STRUCT_DECL and in_cursor.spelling and in_cursor.is_definition():
-                    builder.add_struct(in_cursor)
-        if cursor.spelling and cursor.is_definition():
-            if cursor.kind is CursorKind.STRUCT_DECL:
-                builder.add_struct(cursor)
-            if cursor.kind is CursorKind.ENUM_DECL:
-                builder.add_enum(cursor)
+    def build_model(self, translation_unit):
+        for cursor in translation_unit.cursor.get_children():
+            if cursor.kind is CursorKind.UNEXPOSED_DECL:
+                for in_cursor in cursor.get_children():
+                    if in_cursor.kind is CursorKind.STRUCT_DECL and in_cursor.spelling and in_cursor.is_definition():
+                        self.add_struct(in_cursor)
+            if cursor.spelling and cursor.is_definition():
+                if cursor.kind is CursorKind.STRUCT_DECL:
+                    self.add_struct(cursor)
+                if cursor.kind is CursorKind.ENUM_DECL:
+                    self.add_enum(cursor)
+
+class SupplementaryDefs(object):
+
+    def __init__(self, include_tree):
+
+        self.include_tree = include_tree
+        self.stub_names = [node.name for node in SupplementaryDefs.flatten_nodes(include_tree)]
+        self.stub_defs = SupplementaryDefs.prepare_stubs(include_tree)
+        stubs_lines = len(self.stub_defs)
+        self.stubs_lines_count = stubs_lines and stubs_lines + 1 or 0
+
+    @staticmethod
+    def flatten_nodes(nodes_list):
+        for node in nodes_list:
+            if isinstance(node, model.Include):
+                for node in SupplementaryDefs.flatten_nodes(node.nodes):
+                    yield node
+            else:
+                yield node
+
+    @staticmethod
+    def unique_nodes(include_tree):
+        picked = []
+        for node in SupplementaryDefs.flatten_nodes(include_tree):
+            if node.name not in picked:
+                picked.append(node.name)
+                yield node
+
+    @staticmethod
+    def prepare_stubs(include_tree):
+        def create_stub_definition(node):
+            if isinstance(node, model.Constant):
+                yield "#define {} {}".format(node.name, node.value)
+            elif isinstance(node, model.Enum):
+                for line in _generate_def_enum(node).split('\n'):
+                    # need to have all lines separated to know its count
+                    yield line
+            else:
+                yield "struct {} {{}};".format(node.name)
+
+        flatten_nodes = SupplementaryDefs.unique_nodes(include_tree)
+        return [line for node in flatten_nodes for line in create_stub_definition(node)]
+
+    def prepend_stubs(self, content):
+        if not self.stub_defs:
+            return content
+        return '\n'.join(self.stub_defs) + '\n' + content
+
+    @contextmanager
+    def implicit_supplementation(self, parsed_content):
+        enriched_content = self.prepend_stubs(parsed_content)
+
+        sack_tree = SackModelTree()
+        for include_node in self.include_tree:
+            sack_tree.add_node(include_node)
+
+        yield enriched_content, sack_tree
+
+        sack_tree.remove_nodes(self.stub_names)
 
 
 class SackParser(object):
@@ -192,38 +235,46 @@ class SackParser(object):
             return SackParserStatus("sack input requires libclang and it's not installed")
         return SackParserStatus()
 
-    def __init__(self, include_dirs=[], warn=None, supple_nodes=[]):
+    def __init__(self, include_dirs=[], warn=None, include_tree=[]):
         self.include_dirs = include_dirs
         self.warn = warn
-        self.supple_nodes = supple_nodes
+        self.supples = SupplementaryDefs(include_tree)
 
     def parse(self, content, path, _):
         args_ = ["-I" + x for x in self.include_dirs]
-
         index = Index.create()
-        path = path.encode()
-        content = content.encode()
-        tree = SackModel(self.supple_nodes)
+        with self.supples.implicit_supplementation(content) as (content_, tree):
+            builder = Builder(tree)
+            path = path.encode()
+            content_ = content_.encode()
 
-        try:
-            tu = index.parse(path, args_, unsaved_files=((path, content),))
-        except TranslationUnitLoadError:
-            raise model.ParseError([(path.decode(), 'error parsing translation unit')])
+            try:
+                translation_unit = index.parse(path, args_, unsaved_files=((path, content_),))
+            except TranslationUnitLoadError:
+                raise model.ParseError([(path.decode(), 'error parsing translation unit')])
 
-        if self.warn:
-            unknown_type_name_warning_prog = re.compile("unknown type name '(\w+)'")
-            for diag in tu.diagnostics:
-                spelling = diag.spelling.decode()
-                match = unknown_type_name_warning_prog.search(spelling)
-                if not match or match.group(1) not in tree.names_defined_in_isar:
-                    self.warn(spelling, location=SackParser._get_location(diag.location))
+            self.print_diagnostics(path, translation_unit)
+            builder.build_model(translation_unit)
 
-        build_model(tu, tree, content)
         return tree.nodes
 
-    @staticmethod
-    def _get_location(location):
-        return '%s:%s:%s' % (location.file.name.decode(), location.line, location.column)
+    def print_diagnostics(self, path, translation_unit):
+        if self.warn:
+            for diag in translation_unit.diagnostics:
+                spelling = diag.spelling.decode()
+                location = self._get_location(diag.location, path)
+                self.warn(spelling, location)
+
+    def _get_location(self, location, target_path):
+        location_file = location.file.name.decode()
+        if os.path.basename(location_file) == os.path.basename(target_path):
+            location_line = location.line - self.supples.stubs_lines_count
+            if location_line < 0:
+                location_file = "supplementary_defs_in_{}".format(os.path.basename(target_path))
+                location_line = location.line
+        else:
+            location_line = location.line
+        return '%s:%s:%s' % (location_file, location_line, location.column)
 
 
 def _setup_libclang():

--- a/prophyc/parsers/sack.py
+++ b/prophyc/parsers/sack.py
@@ -264,10 +264,11 @@ class SackParser(object):
 
     def _get_location(self, location, target_path):
         location_file = location.file.name.decode()
-        if os.path.basename(location_file) == os.path.basename(target_path):
+        target_file_name = os.path.basename(target_path.decode())
+        if os.path.basename(location_file) == target_file_name:
             stubs_len = self.supples.stubs_lines_count
             is_in_stubs = location.line < stubs_len
-            stubs_file = "supplementary_defs_in_{}".format(os.path.basename(target_path))
+            stubs_file = "supplementary_defs_in_{}".format(target_file_name)
             location_line = location.line if is_in_stubs else (location.line - stubs_len)
             location_file = location_file if not is_in_stubs else stubs_file
 

--- a/prophyc/tests/test_supplementation.py
+++ b/prophyc/tests/test_supplementation.py
@@ -153,7 +153,6 @@ struct cppX
         args = ["--sack", "--include_isar", str(xml2), "--include_isar", str(xml3),
                 "--python_out", str(tmpdir_cwd), str(cpp)]
         ret, out, err = call_prophyc(args)
-
         assert out == ""
         assert err == ""
         assert ret == 0
@@ -168,4 +167,83 @@ class cppX(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
                    ('defined_deeper_in_xmls', IsarDefC),
                    ('regular_type', prophy.u16),
                    ('typedefed_deeper_in_xmls', IsarDefA)]
+"""
+
+
+@pytest.clang_installed
+def test_sack_supples_array_size_from_isar(isar_test_helper, tmpdir_cwd, call_prophyc):
+    cpp = tmpdir_cwd.join('the_sack.hpp')
+    cppy = tmpdir_cwd.join('the_sack.py')
+    cpp.write("""\
+#include <stdint.h>
+struct cppX
+{
+    IsarV type_from_isar[IsarCONST_A];
+    uint16_t regular_type[IsarCONST_B];
+};
+""")
+
+    with isar_test_helper(ISAR_TEST_SET_1) as (_, xml2, xml3):
+        args = ["--sack", "--include_isar", str(xml2), "--include_isar", str(xml3),
+                "--python_out", str(tmpdir_cwd), str(cpp)]
+        ret, out, err = call_prophyc(args)
+        assert out == ""
+        assert err == ""
+        assert ret == 0
+    assert cppy.read() == """\
+import prophy
+
+from included_by_sack_a import *
+from included_by_sack_b import *
+
+class cppX(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
+    _descriptor = [('type_from_isar', prophy.array(IsarV, size = 4)),
+                   ('regular_type', prophy.array(prophy.u16, size = 16))]
+"""
+
+
+@pytest.clang_installed
+def test_sack_supples_static_consts_values_from_isar(isar_test_helper, tmpdir_cwd, call_prophyc):
+    cpp = tmpdir_cwd.join('the_sack.hpp')
+    cppy = tmpdir_cwd.join('the_sack.py')
+    cpp.write("""\
+#include <stdint.h>
+struct constants
+{
+    static const uint16_t A = IsarCONST_A;
+    static const uint16_t B = IsarCONST_B;
+    static const uint16_t C = A + B;
+};
+
+struct cppX
+{
+    uint8_t straigth[2];
+    uint16_t tricky1[constants::A];
+    uint16_t tricky2[constants::C];
+    uint16_t tricky3[constants::A * constants::B];
+};
+""")
+
+    with isar_test_helper(ISAR_TEST_SET_1) as (_, xml2, xml3):
+        args = ["--sack", "--include_isar", str(xml2), "--include_isar", str(xml3),
+                "--python_out", str(tmpdir_cwd), str(cpp)]
+        ret, out, err = call_prophyc(args)
+        assert out == ""
+        assert err == ""
+        assert ret == 0
+
+    assert cppy.read() == """\
+import prophy
+
+from included_by_sack_a import *
+from included_by_sack_b import *
+
+class constants(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
+    _descriptor = []
+
+class cppX(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
+    _descriptor = [('straigth', prophy.array(prophy.u8, size = 2)),
+                   ('tricky1', prophy.array(prophy.u16, size = 4)),
+                   ('tricky2', prophy.array(prophy.u16, size = 20)),
+                   ('tricky3', prophy.array(prophy.u16, size = 64))]
 """


### PR DESCRIPTION
adding functionality to sack implicit supplementation:
1. Extracted supplementation abstract so it doesn't matter if the supplementation comes from isar, prophy schema or whatever else.
2. Moving more responsibility to clang. Now arrays in sack can be sized with constants defined in implicit includes. Now the clang compiler handles arithmetics of used constants (if any).
