### PR TITLE
Pep8 propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ waf-*
 # Test tools
 .tox
 .cache
-
+.pytest_cache
 .coverage*

--- a/prophy/base_array.py
+++ b/prophy/base_array.py
@@ -23,5 +23,5 @@ class base_array(object):
     def __repr__(self):
         return repr(self._values)
 
-    def sort(self, key_function = lambda x: x):
+    def sort(self, key_function=lambda x: x):
         self._values.sort(key=key_function)

--- a/prophy/container.py
+++ b/prophy/container.py
@@ -3,6 +3,7 @@ from .exception import ProphyError
 from .base_array import base_array
 from .six import xrange
 
+
 def decode_scalar_array(tp, data, pos, endianness, count):
     if count is None:
         items, remainder = divmod(len(data) - pos, tp._SIZE)
@@ -15,6 +16,7 @@ def decode_scalar_array(tp, data, pos, endianness, count):
         values.append(value)
     return values, cursor
 
+
 def scalar_array_eq(self, other):
     if self is other:
         return True
@@ -24,6 +26,7 @@ def scalar_array_eq(self, other):
     # We are presumably comparing against some other sequence type.
     return other == self._values
 
+
 def composite_array_eq(self, other):
     if self is other:
         return True
@@ -31,6 +34,7 @@ def composite_array_eq(self, other):
         raise ProphyError('Can only compare repeated composite fields against '
                           'other repeated composite fields.')
     return self._values == other._values
+
 
 class fixed_scalar_array(base_array):
     __slots__ = []
@@ -60,6 +64,7 @@ class fixed_scalar_array(base_array):
     def _decode_impl(self, data, pos, endianness, _):
         self[:], size = decode_scalar_array(self._TYPE, data, pos, endianness, len(self))
         return size
+
 
 class bound_scalar_array(base_array):
     __slots__ = []
@@ -119,6 +124,7 @@ class bound_scalar_array(base_array):
         self[:], size = decode_scalar_array(self._TYPE, data, pos, endianness, len_hint)
         return max(size, self._SIZE)
 
+
 class fixed_composite_array(base_array):
 
     __slots__ = []
@@ -131,13 +137,14 @@ class fixed_composite_array(base_array):
         return composite_array_eq(self, other)
 
     def _encode_impl(self, endianness):
-        return b"".join(value.encode(endianness, terminal = False) for value in self)
+        return b"".join(value.encode(endianness, terminal=False) for value in self)
 
     def _decode_impl(self, data, pos, endianness, _):
         cursor = 0
         for elem in self:
-            cursor += elem._decode_impl(data, pos + cursor, endianness, terminal = False)
+            cursor += elem._decode_impl(data, pos + cursor, endianness, terminal=False)
         return cursor
+
 
 class bound_composite_array(base_array):
     __slots__ = []
@@ -179,7 +186,7 @@ class bound_composite_array(base_array):
         return composite_array_eq(self, other)
 
     def _encode_impl(self, endianness):
-        return b"".join(value.encode(endianness, terminal = False) for value in self).ljust(self._SIZE, b"\x00")
+        return b"".join(value.encode(endianness, terminal=False) for value in self).ljust(self._SIZE, b"\x00")
 
     def _decode_impl(self, data, pos, endianness, len_hint):
         if self._SIZE > (len(data) - pos):
@@ -188,11 +195,12 @@ class bound_composite_array(base_array):
         cursor = 0
         if not self._SIZE and not self._BOUND:
             while (pos + cursor) < len(data):
-                cursor += self.add()._decode_impl(data, pos + cursor, endianness, terminal = False)
+                cursor += self.add()._decode_impl(data, pos + cursor, endianness, terminal=False)
         else:
             for _ in xrange(len_hint):
-                cursor += self.add()._decode_impl(data, pos + cursor, endianness, terminal = False)
+                cursor += self.add()._decode_impl(data, pos + cursor, endianness, terminal=False)
         return max(cursor, self._SIZE)
+
 
 def array(type_, **kwargs):
     size = kwargs.pop("size", 0)

--- a/prophy/optional.py
+++ b/prophy/optional.py
@@ -2,6 +2,7 @@ from . import scalar
 from .exception import ProphyError
 from .base_array import base_array
 
+
 def optional(cls):
     if issubclass(cls, bytes):
         raise ProphyError("optional bytes not implemented")

--- a/prophy/scalar.py
+++ b/prophy/scalar.py
@@ -2,6 +2,7 @@ import struct
 from .exception import ProphyError
 from .six import long
 
+
 def numeric_decorator(cls, size, id):
     @staticmethod
     def encode(value, endianness):
@@ -27,6 +28,7 @@ def numeric_decorator(cls, size, id):
 
     return cls
 
+
 def int_decorator(size, id, min, max):
     def decorator(cls):
         cls = numeric_decorator(cls, size, id)
@@ -46,6 +48,7 @@ def int_decorator(size, id, min, max):
         return cls
     return decorator
 
+
 def float_decorator(size, id):
     def decorator(cls):
         cls = numeric_decorator(cls, size, id)
@@ -63,45 +66,56 @@ def float_decorator(size, id):
         return cls
     return decorator
 
-@int_decorator(size = 1, id = 'b', min = -(1 << 7), max = (1 << 7) - 1)
+
+@int_decorator(size=1, id='b', min=-(1 << 7), max=(1 << 7) - 1)
 class i8(long):
     __slots__ = []
 
-@int_decorator(size = 2, id = 'h', min = -(1 << 15), max = (1 << 15) - 1)
+
+@int_decorator(size=2, id='h', min=-(1 << 15), max=(1 << 15) - 1)
 class i16(long):
     __slots__ = []
 
-@int_decorator(size = 4, id = 'i', min = -(1 << 31), max = (1 << 31) - 1)
+
+@int_decorator(size=4, id='i', min=-(1 << 31), max=(1 << 31) - 1)
 class i32(long):
     __slots__ = []
 
-@int_decorator(size = 8, id = 'q', min = -(1 << 63), max = (1 << 63) - 1)
+
+@int_decorator(size=8, id='q', min=-(1 << 63), max=(1 << 63) - 1)
 class i64(long):
     __slots__ = []
 
-@int_decorator(size = 1, id = 'B', min = 0, max = (1 << 8) - 1)
+
+@int_decorator(size=1, id='B', min=0, max=(1 << 8) - 1)
 class u8(long):
     __slots__ = []
 
-@int_decorator(size = 2, id = 'H', min = 0, max = (1 << 16) - 1)
+
+@int_decorator(size=2, id='H', min=0, max=(1 << 16) - 1)
 class u16(long):
     __slots__ = []
 
-@int_decorator(size = 4, id = 'I', min = 0, max = (1 << 32) - 1)
+
+@int_decorator(size=4, id='I', min=0, max=(1 << 32) - 1)
 class u32(long):
     __slots__ = []
 
-@int_decorator(size = 8, id = 'Q', min = 0, max = (1 << 64) - 1)
+
+@int_decorator(size=8, id='Q', min=0, max=(1 << 64) - 1)
 class u64(long):
     __slots__ = []
 
-@float_decorator(size = 4, id = 'f')
+
+@float_decorator(size=4, id='f')
 class r32(float):
     __slots__ = []
 
-@float_decorator(size = 8, id = 'd')
+
+@float_decorator(size=8, id='d')
 class r64(float):
     __slots__ = []
+
 
 def add_enum_attributes(cls, enumerators):
 
@@ -129,6 +143,7 @@ def add_enum_attributes(cls, enumerators):
     cls._int_to_name = int_to_name
     cls._check = check
 
+
 class enum_generator(type):
     def __new__(cls, name, bases, attrs):
         attrs["__slots__"] = []
@@ -139,6 +154,7 @@ class enum_generator(type):
             cls._generated = True
             add_enum_attributes(cls, cls._enumerators)
         super(enum_generator, cls).__init__(name, bases, attrs)
+
 
 class enum(u32):
     __slots__ = []
@@ -151,8 +167,10 @@ class enum(u32):
     def number(self):
         return int(self)
 
+
 class enum8(u8, enum):
     __slots__ = []
+
 
 def bytes_(**kwargs):
     size = kwargs.pop("size", 0)

--- a/prophy/scalar.py
+++ b/prophy/scalar.py
@@ -3,16 +3,16 @@ from .exception import ProphyError
 from .six import long
 
 
-def numeric_decorator(cls, size, id):
+def numeric_decorator(cls, size, id_):
     @staticmethod
     def encode(value, endianness):
-        return struct.pack(endianness + id, value)
+        return struct.pack(endianness + id_, value)
 
     @staticmethod
     def decode(data, pos, endianness):
         if (len(data) - pos) < size:
             raise ProphyError("too few bytes to decode integer")
-        value, = struct.unpack(endianness + id, data[pos:(pos + size)])
+        value, = struct.unpack(endianness + id_, data[pos:(pos + size)])
         return value, size
 
     cls._encode = encode
@@ -29,15 +29,15 @@ def numeric_decorator(cls, size, id):
     return cls
 
 
-def int_decorator(size, id, min, max):
+def int_decorator(size, id_, min_, max_):
     def decorator(cls):
-        cls = numeric_decorator(cls, size, id)
+        cls = numeric_decorator(cls, size, id_)
 
         @staticmethod
         def check(value):
             if not isinstance(value, (int, long)):
                 raise ProphyError("not an int")
-            if not min <= value <= max:
+            if not min_ <= value <= max_:
                 raise ProphyError("out of bounds")
             return value
 
@@ -49,9 +49,9 @@ def int_decorator(size, id, min, max):
     return decorator
 
 
-def float_decorator(size, id):
+def float_decorator(size, id_):
     def decorator(cls):
-        cls = numeric_decorator(cls, size, id)
+        cls = numeric_decorator(cls, size, id_)
 
         @staticmethod
         def check(value):
@@ -67,52 +67,52 @@ def float_decorator(size, id):
     return decorator
 
 
-@int_decorator(size=1, id='b', min=-(1 << 7), max=(1 << 7) - 1)
+@int_decorator(size=1, id_='b', min_=-(1 << 7), max_=(1 << 7) - 1)
 class i8(long):
     __slots__ = []
 
 
-@int_decorator(size=2, id='h', min=-(1 << 15), max=(1 << 15) - 1)
+@int_decorator(size=2, id_='h', min_=-(1 << 15), max_=(1 << 15) - 1)
 class i16(long):
     __slots__ = []
 
 
-@int_decorator(size=4, id='i', min=-(1 << 31), max=(1 << 31) - 1)
+@int_decorator(size=4, id_='i', min_=-(1 << 31), max_=(1 << 31) - 1)
 class i32(long):
     __slots__ = []
 
 
-@int_decorator(size=8, id='q', min=-(1 << 63), max=(1 << 63) - 1)
+@int_decorator(size=8, id_='q', min_=-(1 << 63), max_=(1 << 63) - 1)
 class i64(long):
     __slots__ = []
 
 
-@int_decorator(size=1, id='B', min=0, max=(1 << 8) - 1)
+@int_decorator(size=1, id_='B', min_=0, max_=(1 << 8) - 1)
 class u8(long):
     __slots__ = []
 
 
-@int_decorator(size=2, id='H', min=0, max=(1 << 16) - 1)
+@int_decorator(size=2, id_='H', min_=0, max_=(1 << 16) - 1)
 class u16(long):
     __slots__ = []
 
 
-@int_decorator(size=4, id='I', min=0, max=(1 << 32) - 1)
+@int_decorator(size=4, id_='I', min_=0, max_=(1 << 32) - 1)
 class u32(long):
     __slots__ = []
 
 
-@int_decorator(size=8, id='Q', min=0, max=(1 << 64) - 1)
+@int_decorator(size=8, id_='Q', min_=0, max_=(1 << 64) - 1)
 class u64(long):
     __slots__ = []
 
 
-@float_decorator(size=4, id='f')
+@float_decorator(size=4, id_='f')
 class r32(float):
     __slots__ = []
 
 
-@float_decorator(size=8, id='d')
+@float_decorator(size=8, id_='d')
 class r64(float):
     __slots__ = []
 

--- a/prophy/six.py
+++ b/prophy/six.py
@@ -2,7 +2,7 @@
 
 import sys
 
-if sys.version < '3':
+if sys.version < '3':  # pragma: no cover
     long = long
     from itertools import ifilter
     xrange = xrange
@@ -10,7 +10,7 @@ if sys.version < '3':
     def repr_bytes(x):
         return repr(x)
 
-else:
+else:  # pragma: no cover
     long = int
     ifilter = filter
     xrange = range

--- a/prophy/tests/test_array_bound.py
+++ b/prophy/tests/test_array_bound.py
@@ -1,19 +1,22 @@
 import prophy
 import pytest
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def BoundScalarArray():
     class BoundScalarArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("len", prophy.u32),
-                       ("value", prophy.array(prophy.u32, bound = "len"))]
+                       ("value", prophy.array(prophy.u32, bound="len"))]
     return BoundScalarArray
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def BoundCompositeArray(BoundScalarArray):
     class BoundCompositeArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("len", prophy.u32),
-                       ("value", prophy.array(BoundScalarArray, bound = "len"))]
+                       ("value", prophy.array(BoundScalarArray, bound="len"))]
     return BoundCompositeArray
+
 
 def test_bound_scalar_array_assignment(BoundScalarArray):
     x = BoundScalarArray()
@@ -54,6 +57,7 @@ def test_bound_scalar_array_assignment(BoundScalarArray):
     with pytest.raises(Exception):
         x.value[:] = [1, 2, "abc"]
 
+
 def test_bound_scalar_array_copy_from(BoundScalarArray):
     x = BoundScalarArray()
     x.value[:] = [1, 2]
@@ -62,6 +66,7 @@ def test_bound_scalar_array_copy_from(BoundScalarArray):
 
     y.copy_from(x)
     assert y.value[:] == [1, 2]
+
 
 def test_bound_scalar_array_encoding(BoundScalarArray):
     x = BoundScalarArray()
@@ -83,25 +88,27 @@ def test_bound_scalar_array_encoding(BoundScalarArray):
         x.decode(b"\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x02\x00", ">")
     assert 'not all bytes of BoundScalarArray read' in str(e.value)
 
+
 def test_bound_scalar_array_exceptions():
     with pytest.raises(Exception):
         class LengthFieldNonexistent(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-            _descriptor = [("a", prophy.array(prophy.i32, bound = "nonexistent"))]
+            _descriptor = [("a", prophy.array(prophy.i32, bound="nonexistent"))]
     with pytest.raises(Exception):
         class LengthFieldAfter(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-            _descriptor = [("a", prophy.array(prophy.i32, bound = "after")),
+            _descriptor = [("a", prophy.array(prophy.i32, bound="after")),
                            ("after", prophy.i32)]
     with pytest.raises(Exception):
         class LengthFieldIsNotAnInteger(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
             _descriptor = [("not_an_int", "not_an_int"),
-                           ("a", prophy.array(prophy.i32, bound = "not_an_int"))]
+                           ("a", prophy.array(prophy.i32, bound="not_an_int"))]
+
 
 def test_bound_scalar_array_twice_in_struct():
     class X2(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("b_len", prophy.u8),
                        ("a_len", prophy.u8),
-                       ("a", prophy.array(prophy.u8, bound = "a_len")),
-                       ("b", prophy.array(prophy.u8, bound = "b_len"))]
+                       ("a", prophy.array(prophy.u8, bound="a_len")),
+                       ("b", prophy.array(prophy.u8, bound="b_len"))]
 
     x = X2()
 
@@ -113,10 +120,11 @@ def test_bound_scalar_array_twice_in_struct():
     assert [7, 8] == x.a[:]
     assert [1] == x.b[:]
 
+
 def test_bound_scalar_array_with_shift():
     class XS(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("len", prophy.u8),
-                       ("value", prophy.array(prophy.u8, bound = "len", shift = 2))]
+                       ("value", prophy.array(prophy.u8, bound="len", shift=2))]
 
     x = XS()
     x.value[:] = [1, 2, 3, 4]
@@ -138,6 +146,7 @@ def test_bound_scalar_array_with_shift():
         x.decode(b"\x02\x00", ">")
     assert str(e.value) == "not all bytes of XS read"
 
+
 @pytest.mark.parametrize('array_type', [
     'prophy.array(prophy.u8, shift = 2)',
     'prophy.array(prophy.u8, size = 1, shift = 2)',
@@ -148,12 +157,14 @@ def test_bound_scalar_array_with_shift_exceptions(array_type):
         exec(array_type)
     assert str(e.value) == "only shifting bound array implemented"
 
+
 def test_bound_scalar_array_extend(BoundScalarArray):
     x = BoundScalarArray()
     x.value.extend([1, 2])
     assert x.value == [1, 2]
     x.value.extend([])
     assert x.value == [1, 2]
+
 
 def test_bound_composite_array_assignment(BoundScalarArray, BoundCompositeArray):
     x = BoundCompositeArray()
@@ -199,6 +210,7 @@ def test_bound_composite_array_assignment(BoundScalarArray, BoundCompositeArray)
     with pytest.raises(Exception):
         x.value[0] = 5
 
+
 def test_bound_composite_array_copy_from(BoundCompositeArray):
     x = BoundCompositeArray()
     x.value.add().value[:] = [1, 2]
@@ -216,18 +228,20 @@ def test_bound_composite_array_copy_from(BoundCompositeArray):
     y.copy_from(BoundCompositeArray())
     assert len(y.value) == 0
 
+
 def test_bound_composite_array_add():
     class SubType(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("some", prophy.u32),
-                       ("value", prophy.array(prophy.u32, size = 2))]
+                       ("value", prophy.array(prophy.u32, size=2))]
 
     class BoundCompositeArray_(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("len", prophy.u32),
-                       ("value", prophy.array(SubType, bound = "len"))]
+                       ("value", prophy.array(SubType, bound="len"))]
 
     a = BoundCompositeArray_()
-    a.value.add(some = 543)
+    a.value.add(some=543)
     assert a.value[0].some == 543
+
 
 def test_bound_composite_array_encoding(BoundCompositeArray):
     x = BoundCompositeArray()
@@ -265,20 +279,22 @@ value {
     with pytest.raises(Exception):
         x.decode(b"\x00\x00\x00\x00\x00", ">")
 
+
 def test_bound_composite_array_decode_multiple():
     class Y(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [('x', prophy.u8)]
 
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [('num_of_x', prophy.u8),
-                       ('x', prophy.array(Y, bound = 'num_of_x')),
+                       ('x', prophy.array(Y, bound='num_of_x')),
                        ('num_of_y', prophy.u8),
-                       ('y', prophy.array(Y, bound = 'num_of_y')),
+                       ('y', prophy.array(Y, bound='num_of_y')),
                        ('num_of_z', prophy.u8),
-                       ('z', prophy.array(Y, bound = 'num_of_z'))]
+                       ('z', prophy.array(Y, bound='num_of_z'))]
 
     x = X()
     x.decode(b'\x01\x00\x01\x00\x01\x00', '<')
+
 
 def test_bound_composite_add_via_kwargs(BoundCompositeArray):
     x = BoundCompositeArray()

--- a/prophy/tests/test_array_fixed.py
+++ b/prophy/tests/test_array_fixed.py
@@ -1,28 +1,32 @@
 import prophy
 import pytest
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def X():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("x", prophy.u32)]
     return X
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def FixedScalarArray():
     class FixedScalarArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-        _descriptor = [("value", prophy.array(prophy.u32, size = 2))]
+        _descriptor = [("value", prophy.array(prophy.u32, size=2))]
 
     return FixedScalarArray
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def FixedCompositeArray(X):
     class FixedCompositeArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-        _descriptor = [("value", prophy.array(X, size = 2))]
+        _descriptor = [("value", prophy.array(X, size=2))]
     return FixedCompositeArray
+
 
 def test_base_array_operators():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-        _descriptor = [('values', prophy.array(prophy.i16, size = 4))]
+        _descriptor = [('values', prophy.array(prophy.i16, size=4))]
 
     x = X()
     x.values[0] = 123
@@ -37,6 +41,7 @@ def test_base_array_operators():
     assert repr(x.values) == '[123, 0, 4, -1]'
     x.values.sort()
     assert x.values == [-1, 0, 4, 123]
+
 
 def test_fixed_scalar_array_assignment(FixedScalarArray):
     x = FixedScalarArray()
@@ -71,6 +76,7 @@ def test_fixed_scalar_array_assignment(FixedScalarArray):
     y.copy_from(x)
     assert y.value[:] == [6, 7]
 
+
 def test_fixed_scalar_array_operators(FixedScalarArray):
     x = FixedScalarArray()
     y = FixedScalarArray()
@@ -80,45 +86,50 @@ def test_fixed_scalar_array_operators(FixedScalarArray):
     y.value[0] = 23
     assert x.value == y.value
 
+
 def test_fixed_scalar_array_print(FixedScalarArray):
     x = FixedScalarArray()
     x.value[:] = [1, 2]
     assert str(x) == ("value: 1\n"
                       "value: 2\n")
 
+
 def test_fixed_scalar_array_encode(FixedScalarArray):
     x = FixedScalarArray()
     x.value[:] = [1, 2]
     assert x.encode(">") == b"\x00\x00\x00\x01\x00\x00\x00\x02"
+
 
 def test_fixed_scalar_array_decode(FixedScalarArray):
     x = FixedScalarArray()
     x.decode(b"\x00\x00\x00\x01\x00\x00\x00\x02", ">")
     assert x.value[:] == [1, 2]
 
+
 def test_fixed_scalar_array_exception():
     class D(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a_len", prophy.u8),
-                       ("a", prophy.array(prophy.u8, bound = "a_len"))]
+                       ("a", prophy.array(prophy.u8, bound="a_len"))]
 
     class U(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a", prophy.array(prophy.u8))]
 
     with pytest.raises(Exception) as e:
-        prophy.array(D, size = 2)
+        prophy.array(D, size=2)
     assert "static/limited array of dynamic type not allowed" == str(e.value)
 
     with pytest.raises(Exception) as e:
-        prophy.array(U, size = 2)
+        prophy.array(U, size=2)
     assert "static/limited array of dynamic type not allowed" == str(e.value)
 
     with pytest.raises(Exception) as e:
-        prophy.array(D, bound = "a_len", size = 2)
+        prophy.array(D, bound="a_len", size=2)
     assert "static/limited array of dynamic type not allowed" == str(e.value)
 
     with pytest.raises(Exception) as e:
-        prophy.array(U, bound = "a_len", size = 2)
+        prophy.array(U, bound="a_len", size=2)
     assert "static/limited array of dynamic type not allowed" == str(e.value)
+
 
 def test_fixed_composite_array_assignment(FixedCompositeArray):
     x = FixedCompositeArray()
@@ -139,6 +150,7 @@ def test_fixed_composite_array_assignment(FixedCompositeArray):
 
     assert x.value == x.value
 
+
 def test_fixed_composite_array_print(FixedCompositeArray):
     x = FixedCompositeArray()
     x.value[0].x = 1
@@ -150,17 +162,20 @@ def test_fixed_composite_array_print(FixedCompositeArray):
                       "  x: 2\n"
                       "}\n")
 
+
 def test_fixed_composite_array_encode(FixedCompositeArray):
     x = FixedCompositeArray()
     x.value[0].x = 1
     x.value[1].x = 2
     assert x.encode(">") == b"\x00\x00\x00\x01\x00\x00\x00\x02"
 
+
 def test_fixed_composite_array_decode(FixedCompositeArray):
     x = FixedCompositeArray()
     x.decode(b"\x00\x00\x00\x01\x00\x00\x00\x02", ">")
     assert x.value[0].x == 1
     assert x.value[1].x == 2
+
 
 def test_fixed_array_with_enum():
     class E(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
@@ -169,45 +184,49 @@ def test_fixed_array_with_enum():
                         ("E_3", 3)]
 
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-        _descriptor = [("a", prophy.array(E, size = 3))]
+        _descriptor = [("a", prophy.array(E, size=3))]
 
     x = A()
 
     x.encode(">")
 
+
 def test_fixed_array_decode_exception():
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a_len", prophy.u8),
-                       ("a", prophy.array(prophy.u8, bound = "a_len", size = 3))]
+                       ("a", prophy.array(prophy.u8, bound="a_len", size=3))]
 
     with pytest.raises(Exception) as e:
         A().decode(b"\x00", ">")
     assert "A: too few bytes to decode array" == str(e.value)
 
+
 def test_fixed_array_decode_size_over_255():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-        _descriptor = [("x", prophy.array(prophy.u8, size = 300))]
+        _descriptor = [("x", prophy.array(prophy.u8, size=300))]
 
     x = X()
     x.decode(b'\x01' * 300, '<')
     assert len(x.x) == 300
 
+
 def test_fixed_array_decode_multiple_scalar_arrays():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-        _descriptor = [('x', prophy.array(prophy.u8, size = 1)),
-                       ('y', prophy.array(prophy.u8, size = 1)),
-                       ('z', prophy.array(prophy.u8, size = 1))]
+        _descriptor = [('x', prophy.array(prophy.u8, size=1)),
+                       ('y', prophy.array(prophy.u8, size=1)),
+                       ('z', prophy.array(prophy.u8, size=1))]
     x = X()
     x.decode(b'\x00\x00\x00', '<')
+
 
 def test_fixed_array_decode_multiple_composite_arrays():
     class Y(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [('x', prophy.u8)]
 
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-        _descriptor = [('x', prophy.array(Y, size = 1)),
-                       ('y', prophy.array(Y, size = 1)),
-                       ('z', prophy.array(Y, size = 1))]
+        _descriptor = [('x', prophy.array(Y, size=1)),
+                       ('y', prophy.array(Y, size=1)),
+                       ('z', prophy.array(Y, size=1))]
 
     x = X()
     x.decode(b'\x00\x00\x00', '<')

--- a/prophy/tests/test_array_greedy.py
+++ b/prophy/tests/test_array_greedy.py
@@ -1,38 +1,44 @@
 import prophy
 import pytest
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def GreedyScalarArray():
     class GreedyScalarArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x", prophy.array(prophy.u32))]
     return GreedyScalarArray
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Composite():
     class Composite(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x", prophy.u16),
                        ("y", prophy.i16)]
     return Composite
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def GreedyCompositeArray(Composite):
     class GreedyCompositeArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x", prophy.array(Composite))]
     return GreedyCompositeArray
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def ComplexComposite(Composite):
     class ComplexComposite(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("y_len", prophy.u32),
                        ("x", Composite),
-                       ("y", prophy.array(Composite, bound = "y_len"))]
+                       ("y", prophy.array(Composite, bound="y_len"))]
     return ComplexComposite
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def GreedyComplexCompositeArray(ComplexComposite):
     class GreedyComplexCompositeArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("x", prophy.array(ComplexComposite))]
     return GreedyComplexCompositeArray
+
 
 def test_greedy_scalar_array_assignment(GreedyScalarArray):
     a = GreedyScalarArray()
@@ -48,6 +54,7 @@ def test_greedy_scalar_array_assignment(GreedyScalarArray):
     b.copy_from(a)
     assert b.x[:] == [10, 4]
 
+
 def test_greedy_scalar_array_print(GreedyScalarArray):
     a = GreedyScalarArray()
     a.x[:] = [1, 2, 3, 4]
@@ -56,10 +63,12 @@ def test_greedy_scalar_array_print(GreedyScalarArray):
                       "x: 3\n"
                       "x: 4\n")
 
+
 def test_greedy_scalar_array_encode(GreedyScalarArray):
     a = GreedyScalarArray()
     a.x[:] = [1, 2, 3, 4]
     assert a.encode(">") == b"\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x04"
+
 
 def test_greedy_scalar_array_decode(GreedyScalarArray):
     a = GreedyScalarArray()
@@ -68,6 +77,7 @@ def test_greedy_scalar_array_decode(GreedyScalarArray):
 
     with pytest.raises(prophy.ProphyError):
         a.decode(b"\x00\x00\x00\x0a\x00\x00\x00\x04\x00", ">")
+
 
 def test_greedy_composite_array_assignment(GreedyCompositeArray, Composite):
     a = GreedyCompositeArray()
@@ -93,6 +103,7 @@ def test_greedy_composite_array_assignment(GreedyCompositeArray, Composite):
     assert b.x[1].y == 20
     assert b.x[2].x == 1
     assert b.x[2].y == -1
+
 
 def test_greedy_composite_array_print(GreedyCompositeArray, Composite):
     a = GreedyCompositeArray()
@@ -122,6 +133,7 @@ def test_greedy_composite_array_print(GreedyCompositeArray, Composite):
                       "  y: -1\n"
                       "}\n")
 
+
 def test_greedy_composite_array_encode(GreedyCompositeArray, Composite):
     a = GreedyCompositeArray()
     c = Composite()
@@ -131,6 +143,7 @@ def test_greedy_composite_array_encode(GreedyCompositeArray, Composite):
     c = a.x.add()
     c.x, c.y = 1, -1
     assert a.encode(">") == b"\x00\x0a\x00\x14\x00\x0a\x00\x14\x00\x01\xff\xff"
+
 
 def test_greedy_composite_array_decode(GreedyCompositeArray):
     a = GreedyCompositeArray()
@@ -151,6 +164,7 @@ def test_greedy_composite_array_decode(GreedyCompositeArray):
 
     with pytest.raises(Exception):
         a.decode(b"\x00\x0a\x00\x14\x00\x0a\x00\x14\x00\x01\xff\xff\x00", ">")
+
 
 def test_greedy_complex_composite_array_assignment(GreedyComplexCompositeArray):
     a = GreedyComplexCompositeArray()
@@ -195,6 +209,7 @@ def test_greedy_complex_composite_array_assignment(GreedyComplexCompositeArray):
     assert b.x[0].y[1].y == 6
     assert b.x[1].x.x == 7
     assert b.x[1].x.y == 8
+
 
 def test_greedy_complex_composite_array_print(GreedyComplexCompositeArray):
     a = GreedyComplexCompositeArray()
@@ -241,6 +256,7 @@ def test_greedy_complex_composite_array_print(GreedyComplexCompositeArray):
                       "  }\n"
                       "}\n")
 
+
 def test_greedy_complex_composite_array_encode(GreedyComplexCompositeArray):
     a = GreedyComplexCompositeArray()
     c = a.x.add()
@@ -254,6 +270,7 @@ def test_greedy_complex_composite_array_encode(GreedyComplexCompositeArray):
     c.x.x, c.x.y = 7, 8
     assert a.encode(">") == (b"\x00\x00\x00\x02\x00\x01\x00\x02\x00\x03\x00\x04"
                              b"\x00\x05\x00\x06\x00\x00\x00\x00\x00\x07\x00\x08")
+
 
 def test_greedy_complex_composite_array_decode(GreedyComplexCompositeArray):
     a = GreedyComplexCompositeArray()
@@ -283,6 +300,7 @@ def test_greedy_complex_composite_array_decode(GreedyComplexCompositeArray):
         a.decode(b"\x00\x00\x00\x02\x00\x01\x00\x02\x00\x03\x00\x04"
                  b"\x00\x05\x00\x06\x00\x00\x00\x00\x00\x07\x00\x08\x00", ">")
 
+
 def test_greedy_array_exceptions():
     with pytest.raises(Exception) as e:
         class NotLast(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
@@ -295,6 +313,7 @@ def test_greedy_array_exceptions():
             _descriptor = [("x", prophy.array(prophy.u32))]
         prophy.array(GreedyComposite)
     assert "array with unlimited field disallowed" == str(e.value)
+
 
 def test_greedy_array_comparisons():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):

--- a/prophy/tests/test_array_limited.py
+++ b/prophy/tests/test_array_limited.py
@@ -51,7 +51,7 @@ def test_limited_scalar_array_assignment(LimitedScalarArray):
     assert str(err.value) == "exceeded array limit"
 
     b = LimitedScalarArray()
-    b.value[:] == [9, 9]
+    b.value[:] = [9, 9]
     b.copy_from(a)
     assert b.value[:] == [10, 2, 3]
     b.copy_from(b)

--- a/prophy/tests/test_array_limited.py
+++ b/prophy/tests/test_array_limited.py
@@ -1,26 +1,30 @@
 import prophy
 import pytest
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def LimitedScalarArray():
     class LimitedScalarArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("len", prophy.u32),
-                       ("value", prophy.array(prophy.u32, size = 3, bound = "len"))]
+                       ("value", prophy.array(prophy.u32, size=3, bound="len"))]
     return LimitedScalarArray
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Composite():
     class Composite(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x", prophy.u32),
                        ("y", prophy.u32)]
     return Composite
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def LimitedCompositeArray(Composite):
     class LimitedCompositeArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("len", prophy.u32),
-                       ("value", prophy.array(Composite, size = 3, bound = "len"))]
+                       ("value", prophy.array(Composite, size=3, bound="len"))]
     return LimitedCompositeArray
+
 
 def test_limited_scalar_array_assignment(LimitedScalarArray):
     a = LimitedScalarArray()
@@ -53,16 +57,19 @@ def test_limited_scalar_array_assignment(LimitedScalarArray):
     b.copy_from(b)
     assert b.value == [10, 2, 3]
 
+
 def test_limited_scalar_array_print(LimitedScalarArray):
     a = LimitedScalarArray()
     a.value[:] = [1, 2]
     assert str(a) == ("value: 1\n"
                       "value: 2\n")
 
+
 def test_limited_scalar_array_encode(LimitedScalarArray):
     a = LimitedScalarArray()
     a.value[:] = [1, 2]
     assert a.encode(">") == b"\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x00"
+
 
 def test_limited_scalar_array_decode(LimitedScalarArray):
     a = LimitedScalarArray()
@@ -84,6 +91,7 @@ def test_limited_scalar_array_decode(LimitedScalarArray):
     with pytest.raises(prophy.ProphyError) as e:
         a.decode(b"\x00\x00\x00\x00", ">")
     assert 'too few bytes to decode array' in str(e.value)
+
 
 def test_limited_composite_array_assigment(LimitedCompositeArray, Composite):
     a = LimitedCompositeArray()
@@ -121,6 +129,7 @@ def test_limited_composite_array_assigment(LimitedCompositeArray, Composite):
                       "  y: 0\n"
                       "}\n")
 
+
 def test_limited_composite_array_exception(LimitedCompositeArray, Composite):
     a = LimitedCompositeArray()
     c = Composite()
@@ -155,6 +164,7 @@ def test_limited_composite_array_exception(LimitedCompositeArray, Composite):
     with pytest.raises(prophy.ProphyError) as e:
         a.decode((b"\x00\x00\x00\x00"), ">")
     assert "LimitedCompositeArray: too few bytes to decode array" == str(e.value)
+
 
 def test_limited_composite_array_encode(LimitedCompositeArray, Composite):
     a = LimitedCompositeArray()
@@ -191,6 +201,7 @@ def test_limited_composite_array_encode(LimitedCompositeArray, Composite):
                              b"\x11\x00\x00\x00\x00\x00\x00\x00"
                              b"\x11\x00\x00\x00\x00\x00\x00\x00")
 
+
 def test_limited_composite_array_decode(LimitedCompositeArray):
     a = LimitedCompositeArray()
 
@@ -226,6 +237,7 @@ def test_limited_composite_array_decode(LimitedCompositeArray):
     assert a.value[2].x == 0x33
     assert a.value[2].y == 0x39
 
+
 def test_limited_array_with_enum():
     class E(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
         _enumerators = [("E_1", 1),
@@ -234,7 +246,7 @@ def test_limited_array_with_enum():
 
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a_len", prophy.u32),
-                       ("a", prophy.array(E, size = 3, bound = "a_len"))]
+                       ("a", prophy.array(E, size=3, bound="a_len"))]
 
     x = A()
 
@@ -249,13 +261,14 @@ def test_limited_array_with_enum():
 
     assert [3, 1] == x.a[:]
 
+
 def test_limited_array_with_field_afterwards():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a", prophy.u8)]
 
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a_len", prophy.u8),
-                       ("a", prophy.array(S, size = 3, bound = "a_len")),
+                       ("a", prophy.array(S, size=3, bound="a_len")),
                        ("b", prophy.u8)]
 
     x = A()

--- a/prophy/tests/test_attributes.py
+++ b/prophy/tests/test_attributes.py
@@ -1,6 +1,7 @@
 import prophy
 import pytest
 
+
 @pytest.mark.parametrize("tp, size", [
     (prophy.i8, 1),
     (prophy.i16, 2),
@@ -21,6 +22,7 @@ def test_int_attributes(tp, size):
     assert tp._BOUND is None
     assert tp._PARTIAL_ALIGNMENT is None
 
+
 @pytest.mark.parametrize("tp, size", [
     (prophy.r32, 4),
     (prophy.r64, 8)
@@ -35,15 +37,18 @@ def test_float_attributes(tp, size):
     assert tp._BOUND is None
     assert tp._PARTIAL_ALIGNMENT is None
 
+
 def make_E():
     class E(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
         _enumerators = [("E_1", 1)]
     return E
 
+
 def make_E8():
     class E8(prophy.with_metaclass(prophy.enum_generator, prophy.enum8)):
         _enumerators = [("E_1", 1)]
     return E8
+
 
 @pytest.mark.parametrize("tp_factory, size", [
     (make_E, 4),
@@ -58,6 +63,7 @@ def test_enum_attributes(tp_factory, size):
     assert tp_factory()._ALIGNMENT == size
     assert tp_factory()._BOUND is None
     assert tp_factory()._PARTIAL_ALIGNMENT is None
+
 
 def test_optional_attributes():
     assert prophy.optional(prophy.i8)._SIZE == 1
@@ -74,8 +80,9 @@ def test_optional_attributes():
     assert prophy.optional(prophy.i64)._OPTIONAL_SIZE == 16
     assert prophy.optional(prophy.i64)._OPTIONAL_ALIGNMENT == 8
 
+
 def test_bytes_static_attributes():
-    B = prophy.bytes(size = 3)
+    B = prophy.bytes(size=3)
 
     assert B._SIZE == 3
     assert B._DYNAMIC is False
@@ -86,8 +93,9 @@ def test_bytes_static_attributes():
     assert B._BOUND is None
     assert B._PARTIAL_ALIGNMENT is None
 
+
 def test_bytes_limited_attributes():
-    B = prophy.bytes(bound = "a_len", size = 3)
+    B = prophy.bytes(bound="a_len", size=3)
 
     assert B._SIZE == 3
     assert B._DYNAMIC is False
@@ -98,8 +106,9 @@ def test_bytes_limited_attributes():
     assert B._BOUND == "a_len"
     assert B._PARTIAL_ALIGNMENT is None
 
+
 def test_bytes_bound_attributes():
-    B = prophy.bytes(bound = "a_len")
+    B = prophy.bytes(bound="a_len")
 
     assert B._SIZE == 0
     assert B._DYNAMIC is True
@@ -109,6 +118,7 @@ def test_bytes_bound_attributes():
     assert B._ALIGNMENT == 1
     assert B._BOUND == "a_len"
     assert B._PARTIAL_ALIGNMENT is None
+
 
 def test_bytes_greedy_attributes():
     B = prophy.bytes()
@@ -122,8 +132,9 @@ def test_bytes_greedy_attributes():
     assert B._BOUND is None
     assert B._PARTIAL_ALIGNMENT is None
 
+
 def test_array_static_attributes():
-    A = prophy.array(prophy.u16, size = 3)
+    A = prophy.array(prophy.u16, size=3)
 
     assert A._SIZE == 6
     assert A._DYNAMIC is False
@@ -133,8 +144,9 @@ def test_array_static_attributes():
     assert A._BOUND is None
     assert A._PARTIAL_ALIGNMENT is None
 
+
 def test_array_limited_attributes():
-    A = prophy.array(prophy.u16, bound = "a_len", size = 3)
+    A = prophy.array(prophy.u16, bound="a_len", size=3)
 
     assert A._SIZE == 6
     assert A._DYNAMIC is False
@@ -144,8 +156,9 @@ def test_array_limited_attributes():
     assert A._BOUND == "a_len"
     assert A._PARTIAL_ALIGNMENT is None
 
+
 def test_array_bound_attributes():
-    A = prophy.array(prophy.u16, bound = "a_len")
+    A = prophy.array(prophy.u16, bound="a_len")
 
     assert A._SIZE == 0
     assert A._DYNAMIC is True
@@ -154,6 +167,7 @@ def test_array_bound_attributes():
     assert A._ALIGNMENT == 2
     assert A._BOUND == "a_len"
     assert A._PARTIAL_ALIGNMENT is None
+
 
 def test_array_greedy_attributes():
     A = prophy.array(prophy.u16)
@@ -166,60 +180,66 @@ def test_array_greedy_attributes():
     assert A._BOUND is None
     assert A._PARTIAL_ALIGNMENT is None
 
+
 def test_array_incorrect_attributes():
     with pytest.raises(prophy.ProphyError) as err:
-        prophy.array(prophy.u16, anything = 3)
+        prophy.array(prophy.u16, anything=3)
 
     assert str(err.value) == "unknown arguments to array field"
+
 
 def test_array_of_arrays_not_allowed():
     A = prophy.array(prophy.r32)
     with pytest.raises(prophy.ProphyError) as err:
-        prophy.array(A, size = 3)
+        prophy.array(A, size=3)
 
     assert str(err.value) == "array of arrays not allowed"
+
 
 def test_container_len_attributes():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a_len", prophy.u8),
-                       ("a", prophy.bytes(bound = "a_len")),
+                       ("a", prophy.bytes(bound="a_len")),
                        ("b_len", prophy.u8),
-                       ("b", prophy.array(prophy.u8, bound = "b_len"))]
+                       ("b", prophy.array(prophy.u8, bound="b_len"))]
 
     assert [["a"], "a_len", ["b"], "b_len"] == [tpl[1]._BOUND for tpl in S._descriptor]
     assert ["a_len", "a", "b_len", "b"] == [tpl[0] for tpl in S._descriptor]
 
+
 def test_ext_sized_array_attributes_1():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("sizer", prophy.u8),
-                       ("a", prophy.array(prophy.u8, bound = "sizer")),
-                       ("b", prophy.array(prophy.u16, bound = "sizer")),
-                       ("c", prophy.array(prophy.u32, bound = "sizer"))]
+                       ("a", prophy.array(prophy.u8, bound="sizer")),
+                       ("b", prophy.array(prophy.u16, bound="sizer")),
+                       ("c", prophy.array(prophy.u32, bound="sizer"))]
 
     assert [["a", "b", "c"], "sizer", "sizer", "sizer"] == [tpl[1]._BOUND for tpl in S._descriptor]
     assert ["sizer", "a", "b", "c"] == [tpl[0] for tpl in S._descriptor]
+
 
 def test_ext_sized_array_attributes_2():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("sz1", prophy.u8),
                        ("sz2", prophy.u8),
-                       ("a1", prophy.array(prophy.u8, bound = "sz1")),
-                       ("a2", prophy.array(prophy.u16, bound = "sz2")),
-                       ("b1", prophy.array(prophy.u32, bound = "sz1")),
-                       ("b2", prophy.array(prophy.u32, bound = "sz2"))]
+                       ("a1", prophy.array(prophy.u8, bound="sz1")),
+                       ("a2", prophy.array(prophy.u16, bound="sz2")),
+                       ("b1", prophy.array(prophy.u32, bound="sz1")),
+                       ("b2", prophy.array(prophy.u32, bound="sz2"))]
 
     assert [["a1", "b1"], ["a2", "b2"], "sz1", "sz2", "sz1", "sz2"] == [tpl[1]._BOUND for tpl in S._descriptor]
     assert ["sz1", "sz2", "a1", "a2", "b1", "b2"] == [tpl[0] for tpl in S._descriptor]
+
 
 def test_struct_static_attributes():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a", prophy.u8),
                        ("c_len", prophy.u8),
                        ("e_len", prophy.u8),
-                       ("b", prophy.bytes(size = 3)),
-                       ("c", prophy.bytes(bound = "c_len", size = 3)),
-                       ("d", prophy.array(prophy.u8, size = 3)),
-                       ("e", prophy.array(prophy.u8, bound = "e_len", size = 3))]
+                       ("b", prophy.bytes(size=3)),
+                       ("c", prophy.bytes(bound="c_len", size=3)),
+                       ("d", prophy.array(prophy.u8, size=3)),
+                       ("e", prophy.array(prophy.u8, bound="e_len", size=3))]
 
     assert S._SIZE == 15
     assert S._DYNAMIC is False
@@ -232,7 +252,7 @@ def test_struct_static_attributes():
     class S1(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a", S),
                        ("b_len", prophy.u8),
-                       ("b", prophy.array(S, bound = "b_len", size = 3))]
+                       ("b", prophy.array(S, bound="b_len", size=3))]
 
     assert S1._SIZE == 61
     assert S1._DYNAMIC is False
@@ -240,6 +260,7 @@ def test_struct_static_attributes():
     assert S1._OPTIONAL is False
     assert S1._ALIGNMENT == 1
     assert S1._BOUND is None
+
 
 def test_struct_with_optional_attributes():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
@@ -262,13 +283,14 @@ def test_struct_with_optional_attributes():
     assert K._ALIGNMENT == 4
     assert K._BOUND is None
 
+
 def test_struct_dynamic_attributes():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a", prophy.u8)]
 
     class S1(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a_len", prophy.u8),
-                       ("a", prophy.array(prophy.u8, bound = "a_len"))]
+                       ("a", prophy.array(prophy.u8, bound="a_len"))]
 
     assert S1._SIZE == 1
     assert S1._DYNAMIC is True
@@ -278,7 +300,7 @@ def test_struct_dynamic_attributes():
 
     class S2(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a_len", prophy.u8),
-                       ("a", prophy.array(S, bound = "a_len"))]
+                       ("a", prophy.array(S, bound="a_len"))]
 
     assert S2._SIZE == 1
     assert S2._DYNAMIC is True
@@ -295,6 +317,7 @@ def test_struct_dynamic_attributes():
     assert S3._UNLIMITED is False
     assert S3._OPTIONAL is False
     assert S3._ALIGNMENT == 1
+
 
 def test_struct_unlimited_attributes():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
@@ -327,6 +350,7 @@ def test_struct_unlimited_attributes():
     assert S3._OPTIONAL is False
     assert S3._ALIGNMENT == 1
 
+
 def test_struct_padded():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a", prophy.u8),
@@ -351,7 +375,7 @@ def test_struct_padded():
     assert 8 == S3._SIZE
 
     class S4(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-        _descriptor = [("a", prophy.array(prophy.u8, size = 7)),
+        _descriptor = [("a", prophy.array(prophy.u8, size=7)),
                        ("b", prophy.u32)]
 
     assert 4 == S4._ALIGNMENT
@@ -370,10 +394,11 @@ def test_struct_padded():
     assert 4 == S5._ALIGNMENT
     assert 16 == S5._SIZE
 
+
 def test_struct_partially_padded():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x_len", prophy.u8),
-                       ("x", prophy.array(prophy.u8, bound = "x_len")),
+                       ("x", prophy.array(prophy.u8, bound="x_len")),
                        ("y", prophy.u32),
                        ("z", prophy.u64)]
 
@@ -382,24 +407,26 @@ def test_struct_partially_padded():
 
     class Y(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x_len", prophy.u8),
-                       ("x", prophy.array(prophy.u8, bound = "x_len")),
+                       ("x", prophy.array(prophy.u8, bound="x_len")),
                        ("y_len", prophy.u32),
-                       ("y", prophy.array(prophy.u8, bound = "y_len")),
+                       ("y", prophy.array(prophy.u8, bound="y_len")),
                        ("z", prophy.u64)]
 
     assert Y._ALIGNMENT == 8
     assert [tp._PARTIAL_ALIGNMENT for _, tp, _, _ in Y._descriptor] == [None, 4, None, 8, None]
+
 
 def test_bytes_partially_padded():
     class Y(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x_len", prophy.u8),
-                       ("x", prophy.bytes(bound = "x_len")),
+                       ("x", prophy.bytes(bound="x_len")),
                        ("y_len", prophy.u32),
-                       ("y", prophy.bytes(bound = "y_len")),
+                       ("y", prophy.bytes(bound="y_len")),
                        ("z", prophy.u64)]
 
     assert Y._ALIGNMENT == 8
     assert [tp._PARTIAL_ALIGNMENT for _, tp, _, _ in Y._descriptor] == [None, 4, None, 8, None]
+
 
 def test_empty_struct():
     class E(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
@@ -411,6 +438,7 @@ def test_empty_struct():
     assert E._OPTIONAL is False
     assert E._ALIGNMENT == 1
     assert E._BOUND is None
+
 
 def test_union_attributes():
     class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
@@ -426,6 +454,7 @@ def test_union_attributes():
     assert U._BOUND is None
     assert U._PARTIAL_ALIGNMENT is None
 
+
 def test_union_with_discriminator_padding_attributes():
     class U1(prophy.with_metaclass(prophy.union_generator, prophy.union)):
         _descriptor = [("a1", prophy.u8, 0)]
@@ -438,16 +467,17 @@ def test_union_with_discriminator_padding_attributes():
     assert U2._SIZE == 16
     assert U2._ALIGNMENT == 8
 
+
 def test_getting_descriptor():
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-        _descriptor = [("a", prophy.array(prophy.u32, size = 2))]
+        _descriptor = [("a", prophy.array(prophy.u32, size=2))]
 
     class E(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
         _enumerators = [("E_1", 1)]
 
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a", prophy.u8),
-                       ("b", prophy.bytes(size = 5))]
+                       ("b", prophy.bytes(size=5))]
 
     class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
         _descriptor = [("a", prophy.u8, 0),
@@ -460,6 +490,7 @@ def test_getting_descriptor():
     assert len(t.get_descriptor()) == 4
     assert len(t.A.get_descriptor()) == 1
     assert len(t.S.get_descriptor()) == 2
+
 
 def test_field_descriptor_repr():
     class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):

--- a/prophy/tests/test_bytes.py
+++ b/prophy/tests/test_bytes.py
@@ -40,6 +40,13 @@ def GreedyBytes():
     return GreedyBytes
 
 
+def test_bad_bytes_definition():
+    with pytest.raises(prophy.ProphyError) as e:
+        class FixedBytes(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
+            _descriptor = [("value", prophy.bytes(bad_keyword=5))]
+    assert "unknown arguments to bytes field" in str(e.value)
+
+
 def test_fixed_bytes_assignment(FixedBytes):
     x = FixedBytes()
     assert x.value == b"\x00\x00\x00\x00\x00"

--- a/prophy/tests/test_bytes.py
+++ b/prophy/tests/test_bytes.py
@@ -1,38 +1,44 @@
 import prophy
 import pytest
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def FixedBytes():
     class FixedBytes(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-        _descriptor = [("value", prophy.bytes(size = 5))]
+        _descriptor = [("value", prophy.bytes(size=5))]
     return FixedBytes
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def BoundBytes():
     class BoundBytes(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("value_len", prophy.u32),
-                       ("value", prophy.bytes(bound = "value_len"))]
+                       ("value", prophy.bytes(bound="value_len"))]
     return BoundBytes
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def ShiftBoundBytes():
     class ShiftBoundBytes(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("value_len", prophy.u8),
-                       ("value", prophy.bytes(bound = "value_len", shift = 2))]
+                       ("value", prophy.bytes(bound="value_len", shift=2))]
     return ShiftBoundBytes
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def LimitedBytes():
     class LimitedBytes(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("value_len", prophy.u32),
-                       ("value", prophy.bytes(size = 5, bound = "value_len"))]
+                       ("value", prophy.bytes(size=5, bound="value_len"))]
     return LimitedBytes
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def GreedyBytes():
     class GreedyBytes(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("value", prophy.bytes())]
     return GreedyBytes
+
 
 def test_fixed_bytes_assignment(FixedBytes):
     x = FixedBytes()
@@ -58,6 +64,7 @@ def test_fixed_bytes_assignment(FixedBytes):
         x.value = b"123456"
     assert str(e.value) == 'too long'
 
+
 def test_fixed_bytes_copy_from(FixedBytes):
     x = FixedBytes()
     x.value = b'bts'
@@ -66,6 +73,7 @@ def test_fixed_bytes_copy_from(FixedBytes):
 
     y.copy_from(x)
     assert y.value == b"bts\x00\x00"
+
 
 def test_fixed_bytes_encoding(FixedBytes):
     x = FixedBytes()
@@ -86,10 +94,11 @@ def test_fixed_bytes_encoding(FixedBytes):
     with pytest.raises(Exception):
         x.decode(b"\x01\x00\x00\x00", ">")
 
+
 def test_fixed_bytes_twice_in_struct():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-        _descriptor = [("x", prophy.bytes(size = 5)),
-                       ("y", prophy.bytes(size = 5))]
+        _descriptor = [("x", prophy.bytes(size=5)),
+                       ("y", prophy.bytes(size=5))]
     x = X()
     x.x = b"abcde"
     x.y = b"fghij"
@@ -103,6 +112,7 @@ y: 'fghij'
     x.decode(b"abcdefghij", ">")
     assert x.x == b"abcde"
     assert x.y == b"fghij"
+
 
 def test_bound_bytes_assignment(BoundBytes):
     x = BoundBytes()
@@ -123,6 +133,7 @@ def test_bound_bytes_assignment(BoundBytes):
     with pytest.raises(Exception):
         x.value = 3
 
+
 def test_bound_bytes_copy_from(BoundBytes):
     x = BoundBytes()
     x.value = b'bts'
@@ -131,6 +142,7 @@ def test_bound_bytes_copy_from(BoundBytes):
 
     y.copy_from(x)
     assert y.value == b"bts"
+
 
 def test_bound_bytes_encoding(BoundBytes):
     x = BoundBytes()
@@ -155,12 +167,13 @@ def test_bound_bytes_encoding(BoundBytes):
     x.decode(b"\x00\x00\x00\x01\x01", ">")
     assert x.value == b"\x01"
 
+
 def test_bound_bytes_twice_in_struct():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("x_len", prophy.u32),
                        ("y_len", prophy.u32),
-                       ("x", prophy.bytes(bound = "x_len")),
-                       ("y", prophy.bytes(bound = "y_len"))]
+                       ("x", prophy.bytes(bound="x_len")),
+                       ("y", prophy.bytes(bound="y_len"))]
     x = X()
     x.x = b"abcde"
     x.y = b"fghij"
@@ -171,6 +184,7 @@ def test_bound_bytes_twice_in_struct():
     x.decode(b"\x00\x00\x00\x05\x00\x00\x00\x05abcdefghij", ">")
     assert x.x == b"abcde"
     assert x.y == b"fghij"
+
 
 def test_shift_bound_bytes_encoding(ShiftBoundBytes):
     x = ShiftBoundBytes()
@@ -185,6 +199,7 @@ def test_shift_bound_bytes_encoding(ShiftBoundBytes):
 
     x.decode(b"\x03\x01", ">")
     assert x.value == b"\x01"
+
 
 def test_shift_bound_bytes_encoding_exceptions(ShiftBoundBytes):
     x = ShiftBoundBytes()
@@ -201,6 +216,7 @@ def test_shift_bound_bytes_encoding_exceptions(ShiftBoundBytes):
         x.decode(b"\x02\x00", ">")
     assert str(e.value) == "not all bytes of ShiftBoundBytes read"
 
+
 @pytest.mark.parametrize('bytes_type', [
     'prophy.bytes(shift = 2)',
     'prophy.bytes(size = 1, shift = 2)',
@@ -210,6 +226,7 @@ def test_shift_bound_bytes_exceptions(bytes_type):
     with pytest.raises(Exception) as e:
         exec(bytes_type)
     assert str(e.value) == "only shifting bound bytes implemented"
+
 
 def test_limited_bytes_assignment(LimitedBytes):
     x = LimitedBytes()
@@ -232,6 +249,7 @@ def test_limited_bytes_assignment(LimitedBytes):
     with pytest.raises(Exception):
         x.value = b"123456"
 
+
 def test_limited_bytes_copy_from(LimitedBytes):
     x = LimitedBytes()
     x.value = b"bts"
@@ -240,6 +258,7 @@ def test_limited_bytes_copy_from(LimitedBytes):
 
     y.copy_from(x)
     assert y.value == b"bts"
+
 
 def test_limited_bytes_encoding(LimitedBytes):
     x = LimitedBytes()
@@ -261,12 +280,13 @@ def test_limited_bytes_encoding(LimitedBytes):
     x.decode(b"\x00\x00\x00\x01\x01\x00\x00\x00\x00", ">")
     assert x.value == b"\x01"
 
+
 def test_limited_bytes_twice_in_struct():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("x_len", prophy.u32),
                        ("y_len", prophy.u32),
-                       ("x", prophy.bytes(size = 5, bound = "x_len")),
-                       ("y", prophy.bytes(size = 5, bound = "y_len"))]
+                       ("x", prophy.bytes(size=5, bound="x_len")),
+                       ("y", prophy.bytes(size=5, bound="y_len"))]
     x = X()
     x.x = b"abc"
     x.y = b"efgh"
@@ -277,6 +297,7 @@ def test_limited_bytes_twice_in_struct():
     x.decode(b"\x00\x00\x00\x02\x00\x00\x00\x03ab\x00\x00\x00fgh\x00\x00", ">")
     assert x.x == b"ab"
     assert x.y == b"fgh"
+
 
 def test_greedy_bytes_assignment(GreedyBytes):
     x = GreedyBytes()
@@ -293,6 +314,7 @@ def test_greedy_bytes_assignment(GreedyBytes):
     with pytest.raises(Exception):
         x.value = 3
 
+
 def test_greedy_bytes_copy_from(GreedyBytes):
     x = GreedyBytes()
     x.value = b"bts"
@@ -301,6 +323,7 @@ def test_greedy_bytes_copy_from(GreedyBytes):
 
     y.copy_from(x)
     assert y.value == b"bts"
+
 
 def test_greedy_bytes_encoding(GreedyBytes):
     x = GreedyBytes()
@@ -321,6 +344,7 @@ def test_greedy_bytes_encoding(GreedyBytes):
     x.decode(b"\x01", ">")
     assert x.value == b"\x01"
 
+
 def test_greedy_bytes_as_last_field():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("x", prophy.u32),
@@ -335,6 +359,7 @@ def test_greedy_bytes_as_last_field():
     x.decode(b"\x00\x00\x00\x01fgh", ">")
     assert x.x == 1
     assert x.y == b"fgh"
+
 
 def test_greedy_bytes_not_last_exceptions():
     with pytest.raises(prophy.ProphyError):
@@ -356,7 +381,7 @@ def test_greedy_bytes_not_last_exceptions():
 
         class Y2(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
             _descriptor = [("x", prophy.u32),
-                           ("y", prophy.array(Y1, size = 2))]
+                           ("y", prophy.array(Y1, size=2))]
     with pytest.raises(prophy.ProphyError):
         class Z1(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
             _descriptor = [("x", prophy.u32),
@@ -370,6 +395,7 @@ def test_greedy_bytes_not_last_exceptions():
             _descriptor = [("x", Z2),
                            ("y", Z1)]
 
+
 @pytest.mark.parametrize('array_type', [
     'prophy.array(prophy.bytes(size = 5), size = 5)',
     'prophy.array(prophy.bytes(size = 5), bound = "value_len")',
@@ -379,6 +405,7 @@ def test_array_of_bytes_not_allowed(array_type):
     with pytest.raises(prophy.ProphyError) as e:
         exec(array_type)
     assert str(e.value) == 'array of strings not allowed'
+
 
 def test_bytes_non_7bit_ascii_to_string(FixedBytes):
     x = FixedBytes()

--- a/prophy/tests/test_enum.py
+++ b/prophy/tests/test_enum.py
@@ -1,7 +1,8 @@
 import prophy
 import pytest
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Enumeration():
     class Enumeration(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
         _enumerators = [("Enumeration_One", 1),
@@ -9,7 +10,8 @@ def Enumeration():
                         ("Enumeration_Three", 3)]
     return Enumeration
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Enumeration8():
     class Enumeration8(prophy.with_metaclass(prophy.enum_generator, prophy.enum8)):
         _enumerators = [("Enumeration_One", 1),
@@ -17,34 +19,40 @@ def Enumeration8():
                         ("Enumeration_Three", 3)]
     return Enumeration8
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Enum(Enumeration):
     class Enum(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("value", Enumeration)]
     return Enum
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Enum8(Enumeration8):
     class Enum8(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("value", Enumeration8)]
     return Enum8
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def EnumFixedArray(Enumeration):
     class EnumFixedArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-        _descriptor = [("value", prophy.array(Enumeration, size = 2))]
+        _descriptor = [("value", prophy.array(Enumeration, size=2))]
     return EnumFixedArray
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def EnumBoundArray(Enumeration):
     class EnumBoundArray(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("value_len", prophy.u32),
-                       ("value", prophy.array(Enumeration, bound = "value_len"))]
+                       ("value", prophy.array(Enumeration, bound="value_len"))]
     return EnumBoundArray
+
 
 def test_enum_dictionaties(Enumeration):
     assert Enumeration._name_to_int == {'Enumeration_One': 1, 'Enumeration_Two': 2, 'Enumeration_Three': 3}
     assert Enumeration._int_to_name == {1: 'Enumeration_One', 2: 'Enumeration_Two', 3: 'Enumeration_Three'}
+
 
 def test_enum_assignment(Enum):
     x = Enum()
@@ -62,6 +70,7 @@ def test_enum_assignment(Enum):
     y = Enum()
     y.copy_from(x)
     assert y.value == 3
+
 
 def test_enum_encoding(Enum):
     x = Enum()
@@ -85,6 +94,7 @@ def test_enum_encoding(Enum):
         x.decode(b"\x00\x00\x00\x01\x01", ">")
     assert 'not all bytes of Enum read' in str(e.value)
 
+
 def test_enum_exceptions():
     with pytest.raises(Exception):
         class NoEnumerators(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
@@ -96,6 +106,7 @@ def test_enum_exceptions():
     with pytest.raises(Exception):
         class ValueOutOfBounds(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
             _enumerators = [("OutOfBounds", 0xFFFFFFFF + 1)]
+
 
 def test_enum8_encoding(Enum8):
     x = Enum8()
@@ -120,6 +131,7 @@ def test_enum8_encoding(Enum8):
         x.decode(b"\x01\x01", ">")
     assert 'not all bytes of Enum8 read' in str(e.value)
 
+
 def test_enum_with_overlapping_values():
     class ValuesOverlapping(prophy.with_metaclass(prophy.enum_generator, prophy.enum8)):
         _enumerators = [("ValuesOverlapping_First", 42),
@@ -138,6 +150,7 @@ def test_enum_with_overlapping_values():
     assert 42 == x.x
     assert "x: ValuesOverlapping_Second\n" == str(x)
 
+
 def test_enum_fixed_array_assignment(EnumFixedArray):
     x = EnumFixedArray()
     assert x.value == [1, 1]
@@ -152,6 +165,7 @@ def test_enum_fixed_array_assignment(EnumFixedArray):
     y.copy_from(x)
     assert y.value == [2, 2]
 
+
 def test_enum_fixed_array_encoding(EnumFixedArray):
     x = EnumFixedArray()
     x.value[:] = [2, 2]
@@ -165,6 +179,7 @@ def test_enum_fixed_array_encoding(EnumFixedArray):
     assert x.value[0] == 2
     assert x.value[1] == 2
 
+
 def test_enum_bound_array_assignment(EnumBoundArray):
     x = EnumBoundArray()
     assert x.value == []
@@ -175,6 +190,7 @@ def test_enum_bound_array_assignment(EnumBoundArray):
     x.value[0] = 2
     x.value[1] = "Enumeration_Two"
     assert x.value == [2, 2]
+
 
 def test_enum_bound_array_encoding(EnumBoundArray):
     x = EnumBoundArray()
@@ -189,6 +205,7 @@ def test_enum_bound_array_encoding(EnumBoundArray):
     assert x.value[0] == 2
     assert x.value[1] == 2
 
+
 def test_enum_with_0xFFFFFFFF_value():
     class Enum(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
         _enumerators = [('Enum_Infinity', 0xFFFFFFFF)]
@@ -197,6 +214,7 @@ def test_enum_with_0xFFFFFFFF_value():
         _descriptor = [("value", Enum)]
 
     assert Enclosing().value == 0xFFFFFFFF
+
 
 def test_enum_access_to_members():
     class E(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):

--- a/prophy/tests/test_float.py
+++ b/prophy/tests/test_float.py
@@ -1,15 +1,18 @@
 import prophy
 import pytest
 
+
 def Float():
     class Float(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("value", prophy.r32)]
     return Float
 
+
 def Double():
     class Double(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("value", prophy.r64)]
     return Double
+
 
 @pytest.mark.parametrize("FloatTypeFactory", [Float, Double])
 def test_float(FloatTypeFactory):
@@ -27,6 +30,7 @@ def test_float(FloatTypeFactory):
     y.value = 4.1
     y.copy_from(x)
     assert y.value == 1.455
+
 
 @pytest.mark.parametrize("FloatTypeFactory, one, minus_one, too_long, too_short", [
     (Float,

--- a/prophy/tests/test_get_descriptor.py
+++ b/prophy/tests/test_get_descriptor.py
@@ -1,14 +1,16 @@
 import prophy
 import pytest
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Struct():
     class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x", prophy.u32),
                        ("y", prophy.u32)]
     return Struct
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Union(Struct):
     class Union(prophy.with_metaclass(prophy.union_generator, prophy.union)):
         _descriptor = [("a", prophy.u16, 0),
@@ -16,14 +18,16 @@ def Union(Struct):
                        ("c", Struct, 2)]
     return Union
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def NestedStruct(Struct):
     class NestedStruct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a", Struct),
                        ("b", Struct)]
     return NestedStruct
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def DeeplyNestedStruct(NestedStruct, Struct):
     class DeeplyNestedStruct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("m", NestedStruct),
@@ -31,22 +35,26 @@ def DeeplyNestedStruct(NestedStruct, Struct):
                        ("o", prophy.u32)]
     return DeeplyNestedStruct
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def ComplicatedStruct(NestedStruct, Struct, Union):
     class ComplicatedStruct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a", NestedStruct),
                        ("b", prophy.u32),
-                       ("c", prophy.array(Struct, size = 2)),
-                       ("d", prophy.array(Union, size = 2))]
+                       ("c", prophy.array(Struct, size=2)),
+                       ("d", prophy.array(Union, size=2))]
     return ComplicatedStruct
+
 
 def desc_to_tuples(desc):
     return [(fdesc.name, fdesc.kind, fdesc.type) for fdesc in desc]
+
 
 def disc_to_tuple(unionObj, disc):
     unionObj.discriminator = disc
     fields = unionObj.get_discriminated()
     return (fields.name, fields.kind, fields.type)
+
 
 def test_struct_type_get_descriptor(DeeplyNestedStruct, NestedStruct, Struct):
     assert desc_to_tuples(DeeplyNestedStruct.get_descriptor()) == [
@@ -55,6 +63,7 @@ def test_struct_type_get_descriptor(DeeplyNestedStruct, NestedStruct, Struct):
         ('o', prophy.kind.INT, prophy.u32)
     ]
 
+
 def test_struct_instance_get_descriptor(DeeplyNestedStruct, NestedStruct, Struct):
     assert desc_to_tuples(DeeplyNestedStruct().get_descriptor()) == [
         ('m', prophy.kind.STRUCT, NestedStruct),
@@ -62,12 +71,14 @@ def test_struct_instance_get_descriptor(DeeplyNestedStruct, NestedStruct, Struct
         ('o', prophy.kind.INT, prophy.u32)
     ]
 
+
 def test_union_type_get_descriptor(Union, Struct):
     assert desc_to_tuples(Union.get_descriptor()) == [
         ('a', prophy.kind.INT, prophy.u16),
         ('b', prophy.kind.INT, prophy.u32),
         ('c', prophy.kind.STRUCT, Struct)
     ]
+
 
 def test_union_instance_get_discriminated(Union, Struct):
     x = Union()

--- a/prophy/tests/test_integers.py
+++ b/prophy/tests/test_integers.py
@@ -2,7 +2,7 @@ import prophy
 import pytest
 
 
-@pytest.mark.parametrize('IntType, min, max', [
+@pytest.mark.parametrize('IntType, min_, max_', [
     (prophy.i8, -(0x80), 0x7F),
     (prophy.i16, -(0x8000), 0x7FFF),
     (prophy.i32, -(0x80000000), 0x7FFFFFFF),
@@ -12,33 +12,33 @@ import pytest
     (prophy.u32, 0, 0xFFFFFFFF),
     (prophy.u64, 0, 0xFFFFFFFFFFFFFFFF)
 ])
-def test_integer(IntType, min, max):
+def test_integer(IntType, min_, max_):
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("value", IntType)]
 
     x = X()
     assert x.value == 0
-    x.value = max
-    assert x.value == max
-    x.value = min
-    assert x.value == min
+    x.value = max_
+    assert x.value == max_
+    x.value = min_
+    assert x.value == min_
 
     with pytest.raises(prophy.ProphyError) as e:
         x.value = "123"
     assert "not an int" in str(e.value)
 
     with pytest.raises(prophy.ProphyError) as e:
-        x.value = max + 1
+        x.value = max_ + 1
     assert "out of bounds" in str(e.value)
 
     with pytest.raises(prophy.ProphyError) as e:
-        x.value = min - 1
+        x.value = min_ - 1
     assert "out of bounds" in str(e.value)
 
     y = X()
-    y.value == 42
+    y.value = 42
     y.copy_from(x)
-    assert y.value == min
+    assert y.value == min_
 
 
 @pytest.mark.parametrize('IntType, a, encoded_a, b, encoded_b, too_short, too_long', [

--- a/prophy/tests/test_integers.py
+++ b/prophy/tests/test_integers.py
@@ -1,6 +1,7 @@
 import prophy
 import pytest
 
+
 @pytest.mark.parametrize('IntType, min, max', [
     (prophy.i8, -(0x80), 0x7F),
     (prophy.i16, -(0x8000), 0x7FFF),
@@ -38,6 +39,7 @@ def test_integer(IntType, min, max):
     y.value == 42
     y.copy_from(x)
     assert y.value == min
+
 
 @pytest.mark.parametrize('IntType, a, encoded_a, b, encoded_b, too_short, too_long', [
     (prophy.i8,

--- a/prophy/tests/test_optional.py
+++ b/prophy/tests/test_optional.py
@@ -40,6 +40,9 @@ def test_optional_struct():
         _descriptor = [("a", prophy.optional(S))]
 
     x = K()
+    with pytest.raises(prophy.ProphyError, match="assignment to composite field not allowed"):
+        x.a = 123
+
     assert x.a is None
     assert x.encode(">") == b"\x00\x00\x00\x00\x00\x00\x00\x00"
     assert str(x) == """\

--- a/prophy/tests/test_optional.py
+++ b/prophy/tests/test_optional.py
@@ -1,6 +1,7 @@
 import prophy
 import pytest
 
+
 def test_optional_scalar():
     class K(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a", prophy.optional(prophy.u32))]
@@ -29,6 +30,7 @@ a: 10
 
     x.decode(b"\x00\x00\x00\x00\x00\x00\x00\x00", ">")
     assert x.a is None
+
 
 def test_optional_struct():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
@@ -73,6 +75,7 @@ a {
     x.decode(b"\x00\x00\x00\x00\x00\x00\x00\x00", ">")
     assert x.a is None
 
+
 def test_optional_union():
     class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
         _descriptor = [("a", prophy.u32, 5)]
@@ -99,6 +102,7 @@ def test_optional_union():
     x.decode(b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", ">")
     assert x.a is None
 
+
 def test_optional_struct_in_array():
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [('a', prophy.u32),
@@ -109,7 +113,7 @@ def test_optional_struct_in_array():
 
     class C(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [('a_len', prophy.u32),
-                       ('a', prophy.array(B, bound = 'a_len'))]
+                       ('a', prophy.array(B, bound='a_len'))]
 
     x = C()
     x.a.add()
@@ -131,33 +135,37 @@ a {
 }
 """
 
+
 def test_optional_bytes():
     with pytest.raises(Exception) as e:
-        prophy.optional(prophy.bytes(size = 3))
+        prophy.optional(prophy.bytes(size=3))
     assert "optional bytes not implemented" == str(e.value)
+
 
 def test_optional_dynamic_field():
     class Dynamic(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [('a_len', prophy.u32),
-                       ('a', prophy.array(prophy.u8, bound = 'a_len'))]
+                       ('a', prophy.array(prophy.u8, bound='a_len'))]
     with pytest.raises(Exception) as e:
         prophy.optional(Dynamic)
     assert "optional dynamic fields not implemented" == str(e.value)
 
+
 def test_optional_array():
     with pytest.raises(Exception) as e:
-        prophy.optional(prophy.array(prophy.u8, size = 3))
+        prophy.optional(prophy.array(prophy.u8, size=3))
     assert "optional array not implemented" == str(e.value)
 
     with pytest.raises(Exception) as e:
         class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
             _descriptor = [("a_len", prophy.optional(prophy.u32)),
-                           ("a", prophy.array(prophy.u32, bound = "a_len"))]
+                           ("a", prophy.array(prophy.u32, bound="a_len"))]
     assert "array S.a must not be bound to optional field" == str(e.value)
 
     with pytest.raises(Exception) as e:
         prophy.array(prophy.optional(prophy.u32))
     assert "array of optional type not allowed" == str(e.value)
+
 
 def test_optional_padded():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):

--- a/prophy/tests/test_struct.py
+++ b/prophy/tests/test_struct.py
@@ -1,27 +1,31 @@
 import prophy
 import pytest
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Struct():
     class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x", prophy.u32),
                        ("y", prophy.u32)]
     return Struct
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def NestedStruct(Struct):
     class NestedStruct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a", Struct),
                        ("b", Struct)]
     return NestedStruct
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def DeeplyNestedStruct(NestedStruct, Struct):
     class DeeplyNestedStruct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("m", NestedStruct),
                        ("n", Struct),
                        ("o", prophy.u32)]
     return DeeplyNestedStruct
+
 
 def test_struct_assignment(Struct):
     x = Struct()
@@ -48,12 +52,14 @@ def test_struct_assignment(Struct):
     with pytest.raises(Exception):
         y.copy_from(123)
 
+
 def test_struct_print(Struct):
     x = Struct()
     x.x = 1
     x.y = 2
     assert str(x) == ("x: 1\n"
                       "y: 2\n")
+
 
 def test_struct_encode(Struct):
     x = Struct()
@@ -62,12 +68,14 @@ def test_struct_encode(Struct):
     assert x.encode(">") == (b"\x00\x00\x00\x01"
                              b"\x00\x00\x00\x02")
 
+
 def test_struct_decode(Struct):
     x = Struct()
     x.decode((b"\x00\x00\x00\x01"
               b"\x00\x00\x00\x02"), ">")
     assert x.x == 1
     assert x.y == 2
+
 
 def test_nested_struct_assignment(NestedStruct):
     x = NestedStruct()
@@ -95,6 +103,7 @@ def test_nested_struct_assignment(NestedStruct):
     assert y.b.x == 3
     assert y.b.y == 4
 
+
 def test_nested_struct_print(NestedStruct):
     y = NestedStruct()
     y.a.x = 1
@@ -111,6 +120,7 @@ def test_nested_struct_print(NestedStruct):
                       "}\n"
                       )
 
+
 def test_nested_struct_encode(NestedStruct):
     y = NestedStruct()
     y.a.x = 1
@@ -122,6 +132,7 @@ def test_nested_struct_encode(NestedStruct):
                              b"\x00\x00\x00\x03"
                              b"\x00\x00\x00\x04")
 
+
 def test_nested_struct_decode(NestedStruct):
     y = NestedStruct()
     y.decode((b"\x00\x00\x00\x01"
@@ -132,6 +143,7 @@ def test_nested_struct_decode(NestedStruct):
     assert y.a.y == 2
     assert y.b.x == 3
     assert y.b.y == 4
+
 
 def test_deeply_nested_struct_assignment(DeeplyNestedStruct):
     x = DeeplyNestedStruct()
@@ -177,6 +189,7 @@ def test_deeply_nested_struct_assignment(DeeplyNestedStruct):
     assert y.n.y == 6
     assert y.o == 7
 
+
 def test_deeply_nested_struct_print(DeeplyNestedStruct):
     z = DeeplyNestedStruct()
     z.m.a.x = 1
@@ -202,6 +215,7 @@ def test_deeply_nested_struct_print(DeeplyNestedStruct):
                       "}\n"
                       "o: 7\n")
 
+
 def test_deeply_nested_struct_encode(DeeplyNestedStruct):
     z = DeeplyNestedStruct()
     z.m.a.x = 1
@@ -219,6 +233,7 @@ def test_deeply_nested_struct_encode(DeeplyNestedStruct):
                              b"\x00\x00\x00\x06"
                              b"\x00\x00\x00\x07")
 
+
 def test_deeply_nested_struct_decode(DeeplyNestedStruct):
     z = DeeplyNestedStruct()
     z.decode((b"\x00\x00\x00\x01"
@@ -235,6 +250,7 @@ def test_deeply_nested_struct_decode(DeeplyNestedStruct):
     assert z.n.x == 5
     assert z.n.y == 6
     assert z.o == 7
+
 
 def test_empty_struct():
     class Empty(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
@@ -258,10 +274,11 @@ a {
     assert b"" == x.encode(">")
     assert 0 == x.decode("", ">")
 
+
 def test_struct_with_dynamic_fields():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x_len", prophy.u32),
-                       ("x", prophy.array(prophy.u8, bound = "x_len")),
+                       ("x", prophy.array(prophy.u8, bound="x_len")),
                        ("y", prophy.u32)]
 
     assert X._SIZE == 8
@@ -275,14 +292,15 @@ def test_struct_with_dynamic_fields():
     assert x.x[:] == [1]
     assert x.y == 8
 
+
 def test_struct_with_many_arrays():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x_len", prophy.u32),
-                       ("x", prophy.array(prophy.u8, bound = "x_len")),
+                       ("x", prophy.array(prophy.u8, bound="x_len")),
                        ("y_len", prophy.u16),
-                       ("y", prophy.array(prophy.u16, bound = "y_len")),
+                       ("y", prophy.array(prophy.u16, bound="y_len")),
                        ("z_len", prophy.u8),
-                       ("z", prophy.array(prophy.u64, bound = "z_len"))]
+                       ("z", prophy.array(prophy.u64, bound="z_len"))]
     x = X()
     x.x[:] = [1, 2, 3, 4, 5]
     x.y[:] = [1, 2]
@@ -298,12 +316,13 @@ def test_struct_with_many_arrays():
             b"\x00\x00\x00\x00\x00\x00\x00\x02"
             b"\x00\x00\x00\x00\x00\x00\x00\x03") == x.encode('>')
 
+
 def test_struct_with_many_arrays_mixed():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x_len", prophy.u32),
                        ("y_len", prophy.u16),
-                       ("x", prophy.array(prophy.u8, bound = "x_len")),
-                       ("y", prophy.array(prophy.u16, bound = "y_len"))]
+                       ("x", prophy.array(prophy.u8, bound="x_len")),
+                       ("y", prophy.array(prophy.u16, bound="y_len"))]
     x = X()
     x.x[:] = [1, 2, 3, 4, 5]
     x.y[:] = [1, 2]
@@ -314,12 +333,13 @@ def test_struct_with_many_arrays_mixed():
             b"\x05\x00"
             b"\x00\x01\x00\x02") == x.encode('>')
 
+
 def test_struct_with_many_arrays_padding():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x_len", prophy.u8),
-                       ("x", prophy.array(prophy.u8, bound = "x_len")),
+                       ("x", prophy.array(prophy.u8, bound="x_len")),
                        ("y_len", prophy.u32),
-                       ("y", prophy.array(prophy.u8, bound = "y_len")),
+                       ("y", prophy.array(prophy.u8, bound="y_len")),
                        ("z", prophy.u64)]
 
     class Y(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
@@ -354,10 +374,11 @@ def test_struct_with_many_arrays_padding():
     assert x.y.y == [4, 5, 6]
     assert x.y.z == 6
 
+
 def test_struct_with_many_arrays_fixed_tail():
     class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("x_len", prophy.u8),
-                       ("x", prophy.array(prophy.u8, bound = "x_len")),
+                       ("x", prophy.array(prophy.u8, bound="x_len")),
                        ("y", prophy.u32),
                        ("z", prophy.u64)]
 
@@ -383,11 +404,13 @@ def test_struct_with_many_arrays_fixed_tail():
     assert x.y == 5
     assert x.z == 6
 
+
 def test_struct_exception_with_access_to_nonexistent_field():
     with pytest.raises(AttributeError):
         class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
             _descriptor = [("a", prophy.u32)]
         X().im_not_there
+
 
 def test_struct_encoding_with_scalars():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
@@ -406,6 +429,7 @@ def test_struct_encoding_with_scalars():
     assert 6 == x.a
     assert 7 == x.b
     assert 8 == x.c
+
 
 def test_struct_encoding_with_inner_struct():
 
@@ -429,11 +453,12 @@ def test_struct_encoding_with_inner_struct():
     assert 0xb == x.a.b
     assert 0xc == x.b
 
+
 def test_struct_encoding_with_arrays():
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-        _descriptor = [("a", prophy.array(prophy.u8, size = 3)),
+        _descriptor = [("a", prophy.array(prophy.u8, size=3)),
                        ("b_len", prophy.u16),
-                       ("b", prophy.array(prophy.u32, bound = "b_len"))]
+                       ("b", prophy.array(prophy.u32, bound="b_len"))]
 
     x = A()
 
@@ -449,12 +474,13 @@ def test_struct_encoding_with_arrays():
     assert [4, 5, 6] == x.a[:]
     assert [1, 2] == x.b[:]
 
+
 def test_struct_with_multiple_dynamic_fields():
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a_len", prophy.u16),
                        ("b_len", prophy.u8),
-                       ("a", prophy.array(prophy.u32, bound = "a_len")),
-                       ("b", prophy.array(prophy.u8, bound = "b_len"))]
+                       ("a", prophy.array(prophy.u32, bound="a_len")),
+                       ("b", prophy.array(prophy.u8, bound="b_len"))]
     x = A()
     x.a[:] = [1, 2]
     x.b[:] = [3, 4]
@@ -466,10 +492,11 @@ def test_struct_with_multiple_dynamic_fields():
     assert [5] == x.a[:]
     assert [2, 1, 0] == x.b[:]
 
+
 def test_struct_with_greedy_bytes():
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a_len", prophy.u16),
-                       ("a", prophy.array(prophy.u16, bound = "a_len")),
+                       ("a", prophy.array(prophy.u16, bound="a_len")),
                        ("b", prophy.bytes())]
     x = A()
     x.a[:] = [5, 6, 7]
@@ -481,6 +508,7 @@ def test_struct_with_greedy_bytes():
     x.decode(b'\x00\x01\x00\x08abacus\x00\x00', '>')
     assert [8] == x.a[:]
     assert b'abacus\x00\x00' == x.b
+
 
 def test_struct_with_and_without_padding():
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
@@ -527,14 +555,15 @@ def test_struct_with_and_without_padding():
     assert x.c == 6
     assert x.d == 7
 
+
 def test_struct_with_substruct_with_bytes():
     class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("num_of_x", prophy.u32),
-                       ("x", prophy.array(prophy.u8, bound = "num_of_x"))]
+                       ("x", prophy.array(prophy.u8, bound="num_of_x"))]
 
     class B(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("num_of_x", prophy.u32),
-                       ("x", prophy.array(A, bound = "num_of_x"))]
+                       ("x", prophy.array(A, bound="num_of_x"))]
 
     x = B()
     x.x.add().x[:] = [1]

--- a/prophy/tests/test_struct.py
+++ b/prophy/tests/test_struct.py
@@ -103,6 +103,9 @@ def test_nested_struct_assignment(NestedStruct):
     assert y.b.x == 3
     assert y.b.y == 4
 
+    with pytest.raises(prophy.ProphyError, match="assignment to composite field not allowed"):
+        x.a = 23
+
 
 def test_nested_struct_print(NestedStruct):
     y = NestedStruct()

--- a/prophy/tests/test_union.py
+++ b/prophy/tests/test_union.py
@@ -1,7 +1,8 @@
 import prophy
 import pytest
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def SimpleUnion():
     class SimpleUnion(prophy.with_metaclass(prophy.union_generator, prophy.union)):
         _descriptor = [("a", prophy.u32, 0),
@@ -9,7 +10,8 @@ def SimpleUnion():
                        ("c", prophy.u32, 2)]
     return SimpleUnion
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def VariableLengthFieldsUnion():
     class VariableLengthFieldsUnion(prophy.with_metaclass(prophy.union_generator, prophy.union)):
         _descriptor = [("a", prophy.u8, 0),
@@ -17,6 +19,7 @@ def VariableLengthFieldsUnion():
                        ("c", prophy.u32, 2),
                        ("d", prophy.u64, 3)]
     return VariableLengthFieldsUnion
+
 
 def test_simple_union(SimpleUnion):
     x = SimpleUnion()
@@ -33,6 +36,7 @@ def test_simple_union(SimpleUnion):
     assert 'c: 16\n' == str(x)
     assert b'\x00\x00\x00\x02\x00\x00\x00\x10' == x.encode(">")
 
+
 def test_simple_union_discriminator_accepts_ints_or_field_name_and_clears(SimpleUnion):
     x = SimpleUnion()
 
@@ -48,6 +52,7 @@ def test_simple_union_discriminator_accepts_ints_or_field_name_and_clears(Simple
     assert 0 == x.c
     assert 'c: 0\n' == str(x)
     assert b'\x00\x00\x00\x02\x00\x00\x00\x00' == x.encode(">")
+
 
 def test_union_copy_from(SimpleUnion):
     x = SimpleUnion()
@@ -66,6 +71,7 @@ def test_union_copy_from(SimpleUnion):
     assert 1 == y.discriminator
     assert 3 == y.b
 
+
 def test_simple_union_discriminator_does_not_clear_fields_if_set_to_same_value(SimpleUnion):
     x = SimpleUnion()
 
@@ -78,6 +84,7 @@ def test_simple_union_discriminator_does_not_clear_fields_if_set_to_same_value(S
     x.discriminator = "a"
 
     assert 42 == x.a
+
 
 def test_union_nonsequential_discriminators():
     class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
@@ -111,6 +118,7 @@ def test_union_nonsequential_discriminators():
     assert 55 == x.discriminator
     assert 0 == x.c
 
+
 def test_union_encode_according_to_largest_field(VariableLengthFieldsUnion):
     x = VariableLengthFieldsUnion()
 
@@ -133,6 +141,7 @@ def test_union_encode_according_to_largest_field(VariableLengthFieldsUnion):
     x.d = 0x123456789ABCDEF1
     assert b"\x00\x00\x00\x03\x00\x00\x00\x00" b"\x12\x34\x56\x78\x9a\xbc\xde\xf1" == x.encode(">")
     assert b"\x03\x00\x00\x00\x00\x00\x00\x00" b"\xf1\xde\xbc\x9a\x78\x56\x34\x12" == x.encode("<")
+
 
 def test_union_decode_according_to_largest_field(VariableLengthFieldsUnion):
     x = VariableLengthFieldsUnion()
@@ -168,6 +177,7 @@ def test_union_decode_according_to_largest_field(VariableLengthFieldsUnion):
     assert 16 == x.decode(b"\x03\x00\x00\x00\x00\x00\x00\x00" b"\xf1\xde\xbc\x9a\x78\x56\x34\x12", "<")
     assert 3 == x.discriminator
     assert 0x123456789ABCDEF1 == x.d
+
 
 def test_union_with_struct():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
@@ -220,6 +230,7 @@ def test_union_with_struct():
         x.b = 'anythig'
     assert str(err.value) == 'assignment to composite field not allowed'
 
+
 def test_union_discriminator_exceptions(VariableLengthFieldsUnion):
     x = VariableLengthFieldsUnion()
 
@@ -249,6 +260,7 @@ def test_union_discriminator_exceptions(VariableLengthFieldsUnion):
     assert 1 == x.discriminator
     assert 42 == x.b
 
+
 def test_union_decode_exceptions(VariableLengthFieldsUnion):
     x = VariableLengthFieldsUnion()
 
@@ -263,6 +275,7 @@ def test_union_decode_exceptions(VariableLengthFieldsUnion):
     with pytest.raises(Exception) as e:
         x.decode(b"\x00\x00\x00\x02\x00\x00\x00\x00" b"\x12\x34\x56\x78\x00\x00\x00", ">")
     assert "not enough bytes" == str(e.value)
+
 
 def test_struct_with_union():
     class UVarLen(prophy.with_metaclass(prophy.union_generator, prophy.union)):
@@ -300,6 +313,7 @@ b {
 c: 32
 """ == str(x)
 
+
 def test_array_with_union():
     class UVarLen(prophy.with_metaclass(prophy.union_generator, prophy.union)):
         _descriptor = [("a", prophy.u16, 0),
@@ -308,7 +322,7 @@ def test_array_with_union():
 
     class StructWithU(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
         _descriptor = [("a_len", prophy.u8),
-                       ("a", prophy.array(UVarLen, bound = "a_len"))]
+                       ("a", prophy.array(UVarLen, bound="a_len"))]
 
     x = StructWithU()
 
@@ -352,6 +366,7 @@ a {
 }
 """ == str(x)
 
+
 def test_union_with_plain_struct():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a", prophy.u8),
@@ -380,15 +395,16 @@ b {
 }
 """ == str(x)
 
+
 def test_union_with_struct_with_array_and_bytes():
     class S(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
         _descriptor = [("a", prophy.u8)]
 
     class SBytesSized(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-        _descriptor = [("a", prophy.bytes(size = 3))]
+        _descriptor = [("a", prophy.bytes(size=3))]
 
     class SArraySized(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
-        _descriptor = [("a", prophy.array(S, size = 3))]
+        _descriptor = [("a", prophy.array(S, size=3))]
 
     class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
         _descriptor = [("a", SBytesSized, 0),
@@ -425,6 +441,7 @@ b {
   }
 }
 """ == str(x)
+
 
 def test_union_with_nested_struct_and_union():
     class SInner(prophy.with_metaclass(prophy.struct_generator, prophy.struct_packed)):
@@ -467,6 +484,7 @@ a {
     assert 1 == y.a.discriminator
     assert 8 == y.a.b
 
+
 def test_union_with_typedef_and_enum():
     TU16 = prophy.u16
 
@@ -496,6 +514,7 @@ def test_union_with_typedef_and_enum():
 b: E_1
 """ == str(x)
 
+
 def test_union_exceptions_with_dynamic_arrays_and_bytes():
     with pytest.raises(Exception) as e:
         class U1(prophy.with_metaclass(prophy.union_generator, prophy.union)):
@@ -505,7 +524,7 @@ def test_union_exceptions_with_dynamic_arrays_and_bytes():
     with pytest.raises(Exception) as e:
         class U2(prophy.with_metaclass(prophy.union_generator, prophy.union)):
             _descriptor = [("a_len", prophy.u8, 0),
-                           ("a", prophy.array(prophy.u32, bound = "a_len"), 1)]
+                           ("a", prophy.array(prophy.u32, bound="a_len"), 1)]
     assert "dynamic types not allowed in union" == str(e.value)
 
     with pytest.raises(Exception) as e:
@@ -516,8 +535,9 @@ def test_union_exceptions_with_dynamic_arrays_and_bytes():
     with pytest.raises(Exception) as e:
         class U4(prophy.with_metaclass(prophy.union_generator, prophy.union)):
             _descriptor = [("a_len", prophy.u8, 0),
-                           ("a", prophy.bytes(bound = "a_len"), 1)]
+                           ("a", prophy.bytes(bound="a_len"), 1)]
     assert "dynamic types not allowed in union" == str(e.value)
+
 
 def test_union_exceptions_with_nested_limited_greedy_dynamic_arrays_and_bytes():
     with pytest.raises(Exception) as e:
@@ -531,27 +551,29 @@ def test_union_exceptions_with_nested_limited_greedy_dynamic_arrays_and_bytes():
             _descriptor = [("a", S, 0)]
     assert "dynamic types not allowed in union" == str(e.value)
 
+
 def test_union_with_limited_array_and_bytes():
     with pytest.raises(Exception) as e:
         class U1(prophy.with_metaclass(prophy.union_generator, prophy.union)):
             _descriptor = [("a_len", prophy.u8, 0),
-                           ("a", prophy.bytes(bound = "a_len", size = 3), 1)]
+                           ("a", prophy.bytes(bound="a_len", size=3), 1)]
     assert "bound array/bytes not allowed in union" == str(e.value)
 
     with pytest.raises(Exception) as e:
         class U2(prophy.with_metaclass(prophy.union_generator, prophy.union)):
             _descriptor = [("a_len", prophy.u8, 0),
-                           ("a", prophy.array(prophy.u32, bound = "a_len", size = 3), 1)]
+                           ("a", prophy.array(prophy.u32, bound="a_len", size=3), 1)]
     assert "bound array/bytes not allowed in union" == str(e.value)
 
     with pytest.raises(Exception) as e:
         class U3(prophy.with_metaclass(prophy.union_generator, prophy.union)):
-            _descriptor = [("a", prophy.array(prophy.u8, size = 3), 0)]
+            _descriptor = [("a", prophy.array(prophy.u8, size=3), 0)]
     assert "static array not implemented in union" == str(e.value)
+
 
 def test_union_with_static_bytes():
     class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
-        _descriptor = [("a", prophy.bytes(size = 3), 0)]
+        _descriptor = [("a", prophy.bytes(size=3), 0)]
 
     x = U()
 
@@ -562,6 +584,7 @@ def test_union_with_static_bytes():
     assert """\
 a: '\\x01\\x02\\x03'
 """ == str(x)
+
 
 def test_union_with_optional_exception():
     with pytest.raises(Exception) as e:

--- a/prophyc/__init__.py
+++ b/prophyc/__init__.py
@@ -10,8 +10,10 @@ from contextlib import contextmanager
 
 __version__ = '1.1.2'
 
+
 class ProphycError(Exception):
     pass
+
 
 class Emit(object):
     def __init__(self):
@@ -23,6 +25,7 @@ class Emit(object):
 
     def error(self, msg, location='prophyc'):
         raise ProphycError(location + ': error: ' + msg)
+
 
 def main(args):
     emit = Emit()
@@ -70,9 +73,11 @@ def main(args):
             nodes = file_parser(input_file)
         generate_target_files(emit, serializers, get_basename(input_file), nodes)
 
+
 def get_isar_parser(emit):
     from prophyc.parsers.isar import IsarParser
     return IsarParser(warn=emit.warn)
+
 
 def get_target_parser(emit, opts, supplementary_nodes):
     if opts.isar:
@@ -87,6 +92,7 @@ def get_target_parser(emit, opts, supplementary_nodes):
         from prophyc.parsers.prophy import ProphyParser
         return ProphyParser()
 
+
 def get_serializers(opts):
     serializers = []
     if opts.python_out:
@@ -100,11 +106,13 @@ def get_serializers(opts):
         serializers.append(CppFullGenerator(opts.cpp_full_out))
     return serializers
 
+
 def get_patcher(opts):
     if opts.patch:
         from prophyc import patch
         patches = patch.parse(opts.patch)
         return lambda nodes: patch.patch(nodes, patches)
+
 
 class ModelParser():
     def __init__(self, parser, patcher, emit):
@@ -122,8 +130,10 @@ class ModelParser():
         model.evaluate_sizes(nodes, warn=self.emit.warn)
         return nodes
 
+
 def get_basename(path):
     return os.path.splitext(os.path.basename(path))[0]
+
 
 def flatten_included_defs(supple_nodes):
     def get_nodes_and_names(nodes_list):
@@ -135,12 +145,14 @@ def flatten_included_defs(supple_nodes):
     """ pass trough a dictionary to avoid duplicates """
     return tuple(dict(get_nodes_and_names(supple_nodes)).items())
 
+
 def generate_target_files(emit, serializers, basename, nodes):
     for serializer in serializers:
         try:
             serializer.serialize(nodes, basename)
         except model.GenerateError as e:
             emit.error(str(e))
+
 
 @contextmanager
 def error_on_exception(emit):

--- a/prophyc/__main__.py
+++ b/prophyc/__main__.py
@@ -1,11 +1,13 @@
 import sys
 from . import main
 
+
 def entry_main(args=sys.argv[1:]):
     try:
         main(args)
     except Exception as e:
         sys.exit(str(e))
+
 
 if __name__ == '__main__':
     sys.exit(entry_main())

--- a/prophyc/calc.py
+++ b/prophyc/calc.py
@@ -99,13 +99,13 @@ class Calc(Parser):
     def p_error(self, p):
         raise ParseError("syntax error at '%s'" % p.value)
 
-    def eval(self, expr, vars):
-        self.vars = vars
+    def eval(self, expr, vars_):
+        self.vars = vars_
         return super(Calc, self).eval(expr)
 
 
 calc = Calc()
 
 
-def eval(expr, vars):
-    return calc.eval(expr, vars)
+def eval(expr, vars_):
+    return calc.eval(expr, vars_)

--- a/prophyc/calc.py
+++ b/prophyc/calc.py
@@ -1,7 +1,10 @@
 import ply.lex as lex
 import ply.yacc as yacc
 
-class ParseError(Exception): pass
+
+class ParseError(Exception):
+    pass
+
 
 class Parser(object):
     """
@@ -11,11 +14,12 @@ class Parser(object):
     precedence = ()
 
     def __init__(self):
-        self.lexer = lex.lex(module = self, debug = 0)
-        self.parser = yacc.yacc(module = self, tabmodule = 'parsetab_calc', write_tables = 0, debug = 0)
+        self.lexer = lex.lex(module=self, debug=0)
+        self.parser = yacc.yacc(module=self, tabmodule='parsetab_calc', write_tables=0, debug=0)
 
     def eval(self, expr):
-        return self.parser.parse(expr, lexer = self.lexer)
+        return self.parser.parse(expr, lexer=self.lexer)
+
 
 class Calc(Parser):
     tokens = ('NAME', 'NUMBER', 'LSHIFT', 'RSHIFT')
@@ -58,12 +62,18 @@ class Calc(Parser):
                       | expression '/' expression
                       | expression LSHIFT expression
                       | expression RSHIFT expression'''
-        if p[2] == '+': p[0] = p[1] + p[3]
-        elif p[2] == '-': p[0] = p[1] - p[3]
-        elif p[2] == '*': p[0] = p[1] * p[3]
-        elif p[2] == '/': p[0] = p[1] / p[3]
-        elif p[2] == '<<': p[0] = p[1] << p[3]
-        elif p[2] == '>>': p[0] = p[1] >> p[3]
+        if p[2] == '+':
+            p[0] = p[1] + p[3]
+        elif p[2] == '-':
+            p[0] = p[1] - p[3]
+        elif p[2] == '*':
+            p[0] = p[1] * p[3]
+        elif p[2] == '/':
+            p[0] = p[1] / p[3]
+        elif p[2] == '<<':
+            p[0] = p[1] << p[3]
+        elif p[2] == '>>':
+            p[0] = p[1] >> p[3]
 
     def p_expression_uminus(self, p):
         "expression : '-' expression %prec UMINUS"
@@ -95,6 +105,7 @@ class Calc(Parser):
 
 
 calc = Calc()
+
 
 def eval(expr, vars):
     return calc.eval(expr, vars)

--- a/prophyc/file_processor.py
+++ b/prophyc/file_processor.py
@@ -1,19 +1,23 @@
 import os
 from contextlib import contextmanager
 
+
 class CyclicIncludeError(Exception):
     def __init__(self, path):
         Exception.__init__(self, "file %s included again during parsing" % path)
 
+
 class FileNotFoundError(Exception):
     def __init__(self, path):
         Exception.__init__(self, "file %s not found" % path)
+
 
 def _get_first_existing_path(leaf, dirs):
     for dir in dirs:
         path = os.path.join(dir, leaf)
         if os.path.exists(path):
             return path
+
 
 @contextmanager
 def push_dir(dirs, dir):
@@ -23,6 +27,7 @@ def push_dir(dirs, dir):
     finally:
         dirs.pop(0)
 
+
 @contextmanager
 def swap_dir(dirs, dir):
     try:
@@ -31,6 +36,7 @@ def swap_dir(dirs, dir):
         yield dirs
     finally:
         dirs[0] = tmp
+
 
 class FileProcessor(object):
 

--- a/prophyc/file_processor.py
+++ b/prophyc/file_processor.py
@@ -13,26 +13,26 @@ class FileNotFoundError(Exception):
 
 
 def _get_first_existing_path(leaf, dirs):
-    for dir in dirs:
-        path = os.path.join(dir, leaf)
+    for directory in dirs:
+        path = os.path.join(directory, leaf)
         if os.path.exists(path):
             return path
 
 
 @contextmanager
-def push_dir(dirs, dir):
+def push_dir(dirs, directory):
     try:
-        dirs.insert(0, dir)
+        dirs.insert(0, directory)
         yield dirs
     finally:
         dirs.pop(0)
 
 
 @contextmanager
-def swap_dir(dirs, dir):
+def swap_dir(dirs, directory):
     try:
         tmp = dirs[0]
-        dirs[0] = dir
+        dirs[0] = directory
         yield dirs
     finally:
         dirs[0] = tmp

--- a/prophyc/generators/python.py
+++ b/prophyc/generators/python.py
@@ -6,11 +6,14 @@ libname = "prophy"
 primitive_types = {x + y: "%s.%s" % (libname, x + y) for x in "uir" for y in ["8", "16", "32", "64"]}
 primitive_types['byte'] = '%s.u8' % libname
 
+
 def _generate_include(include):
     return "from %s import *" % include.name.split("/")[-1]
 
+
 def _generate_constant(constant):
     return "%s = %s" % constant
+
 
 def _generate_typedef(typedef):
     return "%s = %s" % (
@@ -19,11 +22,14 @@ def _generate_typedef(typedef):
         ".".join((libname, typedef.type_)) or
         typedef.type_)
 
+
 def _generate_enum_members(members):
     return (",\n" + " " * 21).join(("('%s', %s)" % (member.name, member.value) for member in members))
 
+
 def _generate_enum_constants(members):
     return "\n".join(("%s = %s" % (member.name, member.value) for member in members))
+
 
 def _generate_enum(enum):
     return ("class {1}({0}.with_metaclass({0}.enum_generator, {0}.enum)):\n"
@@ -33,6 +39,7 @@ def _generate_enum(enum):
                           enum.name,
                           _generate_enum_members(enum.members),
                           _generate_enum_constants(enum.members))
+
 
 def _generate_struct_member(member):
     prefixed_type = primitive_types.get(member.type_, member.type_)
@@ -50,8 +57,10 @@ def _generate_struct_member(member):
             prefixed_type = '%s.array(%s)' % (libname, ', '.join([prefixed_type] + elem_strs))
     return "('%s', %s)" % (member.name, prefixed_type)
 
+
 def _generate_struct_members(keys):
     return (",\n" + " " * 19).join((_generate_struct_member(member) for member in keys))
+
 
 def _generate_struct(struct):
     return ("class {1}({0}.with_metaclass({0}.struct_generator, {0}.struct)):\n"
@@ -59,12 +68,15 @@ def _generate_struct(struct):
                                               struct.name,
                                               _generate_struct_members(struct.members))
 
+
 def _generate_union_member(member):
     prefixed_type = ".".join((libname, member.type_)) if member.type_ in primitive_types else member.type_
     return "('%s', %s, %s)" % (member.name, prefixed_type, member.discriminator)
 
+
 def _generate_union_members(members):
     return (",\n" + " " * 19).join(_generate_union_member(member) for member in members)
+
 
 def _generate_union(union):
     return ("class {1}({0}.with_metaclass({0}.union_generator, {0}.union)):\n"
@@ -82,8 +94,10 @@ generate_visitor = {
     model.Union: _generate_union
 }
 
+
 def _generate(node):
     return generate_visitor[type(node)](node)
+
 
 def _generator(nodes):
     last_node = None
@@ -94,9 +108,10 @@ def _generator(nodes):
         yield prepend_newline * '\n' + _generate(node) + '\n'
         last_node = node
 
+
 class PythonGenerator(object):
 
-    def __init__(self, output_dir = "."):
+    def __init__(self, output_dir="."):
         self.output_dir = output_dir
 
     def generate_definitions(self, nodes):

--- a/prophyc/model.py
+++ b/prophyc/model.py
@@ -241,7 +241,7 @@ def split_after(nodes, pred):
         yield part
 
 
-def null_warn(str):
+def null_warn(_):
     pass
 
 
@@ -251,7 +251,7 @@ def null_warn(str):
 def topological_sort(nodes):
     """Sorts nodes."""
 
-    def get_include_deps(include):
+    def get_include_deps(_):
         return []
 
     def get_constant_deps(constant):
@@ -288,8 +288,8 @@ def topological_sort(nodes):
         node = nodes[index]
         for dep in get_deps(node):
             if dep not in known and dep in available:
-                found_index, found = next(ifilter(lambda x: x[1].name == dep,
-                                                  enumerate(islice(nodes, index + 1, None), start=index + 1)))
+                found_index, _ = next(ifilter(lambda x: x[1].name == dep,
+                                              enumerate(islice(nodes, index + 1, None), start=index + 1)))
                 nodes.insert(index, nodes.pop(found_index))
                 return True
         known.add(node.name)

--- a/prophyc/options.py
+++ b/prophyc/options.py
@@ -1,15 +1,18 @@
 import os
 import argparse
 
+
 def readable_dir(string):
     if not os.path.isdir(string):
         raise argparse.ArgumentTypeError("%s directory not found" % string)
     return string
 
+
 def readable_file(string):
     if not os.path.isfile(string):
         raise argparse.ArgumentTypeError("%s file not found" % string)
     return string
+
 
 def parse_options(emit_error, args):
     class ArgumentParser(argparse.ArgumentParser):
@@ -17,70 +20,70 @@ def parse_options(emit_error, args):
             emit_error(message)
 
     parser = ArgumentParser('prophyc',
-                            description = ('Parse input files and generate '
-                                           'output based on options given.'))
+                            description=('Parse input files and generate '
+                                         'output based on options given.'))
 
     parser.add_argument('input_files',
-                        metavar = 'INPUT_FILE',
-                        type = readable_file,
-                        nargs = '*',
-                        help = ('Prophy language, C++ or isar xml files with definitions of prophy '
-                                'messages. By default prophy language is assumed.'))
+                        metavar='INPUT_FILE',
+                        type=readable_file,
+                        nargs='*',
+                        help=('Prophy language, C++ or isar xml files with definitions of prophy '
+                              'messages. By default prophy language is assumed.'))
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--isar',
-                       action = 'store_true',
-                       help = 'Parse input files as isar xml.')
+                       action='store_true',
+                       help='Parse input files as isar xml.')
     group.add_argument('--sack',
-                       action = 'store_true',
-                       help = 'Parse input files as sack C++.')
+                       action='store_true',
+                       help='Parse input files as sack C++.')
 
     parser.add_argument('-I', '--include_dir',
-                        metavar = 'DIR',
-                        dest = 'include_dirs',
-                        type = readable_dir,
-                        action = 'append',
-                        default = [],
-                        help = ('Add the directory to the list of directories to be '
+                        metavar='DIR',
+                        dest='include_dirs',
+                        type=readable_dir,
+                        action='append',
+                        default=[],
+                        help=('Add the directory to the list of directories to be '
                                 'searched for included files.'))
 
     parser.add_argument('-S', '--include_isar',
-                        metavar = 'XMLFILE',
-                        dest = 'isar_includes',
-                        type = readable_file,
-                        action = 'append',
-                        default = [],
-                        help = 'Add isar source file for other languages compilation.')
+                        metavar='XMLFILE',
+                        dest='isar_includes',
+                        type=readable_file,
+                        action='append',
+                        default=[],
+                        help='Add isar source file for other languages compilation.')
 
     parser.add_argument('-p', '--patch',
-                        metavar = 'FILE',
-                        type = readable_file,
-                        help = ("File with instructions changing definitions of prophy "
-                                "messages after parsing. It's needed in sack and isar "
+                        metavar='FILE',
+                        type=readable_file,
+                        help=("File with instructions changing definitions of prophy "
+                              "messages after parsing. It's needed in sack and isar "
                                 "modes, since C++ and isar xml are unable to express "
                                 "all prophy features."))
 
     parser.add_argument('--python_out',
-                        metavar = 'OUT_DIR',
-                        type = readable_dir,
-                        help = 'Generate Python source files.')
+                        metavar='OUT_DIR',
+                        type=readable_dir,
+                        help='Generate Python source files.')
 
     parser.add_argument('--cpp_out',
-                        metavar = 'OUT_DIR',
-                        type = readable_dir,
-                        help = 'Generate C++ simple POD-based codec header and source files.')
+                        metavar='OUT_DIR',
+                        type=readable_dir,
+                        help='Generate C++ simple POD-based codec header and source files.')
 
     parser.add_argument('--cpp_full_out',
-                        metavar = 'OUT_DIR',
-                        type = readable_dir,
-                        help = 'Generate C++ full object-based codec header and source files.')
+                        metavar='OUT_DIR',
+                        type=readable_dir,
+                        help='Generate C++ full object-based codec header and source files.')
 
     parser.add_argument('--version',
-                        action = 'store_true',
-                        help = 'Show version information and exit.')
+                        action='store_true',
+                        help='Show version information and exit.')
 
     parser.add_argument('--quiet',
-                        action = 'store_true',
-                        help = 'Suppress warnings prints.')
+                        action='store_true',
+                        help='Suppress warnings prints.')
 
     return parser.parse_args(args)

--- a/prophyc/parsers/prophy.py
+++ b/prophyc/parsers/prophy.py
@@ -5,11 +5,14 @@ import ply.lex as lex
 import ply.yacc as yacc
 
 from prophyc.six import ifilter
-from prophyc.model import Include, Constant, Typedef, Enum, EnumMember, Struct, StructMember, Union, UnionMember, Kind, ParseError
+from prophyc.model import Include, Constant, Typedef, Enum, EnumMember, Struct, StructMember, Union, UnionMember, \
+    Kind, ParseError
 from prophyc.file_processor import CyclicIncludeError, FileNotFoundError
 
-def get_column(input, pos):
-    return pos - input.rfind('\n', 0, pos)
+
+def get_column(input_, pos):
+    return pos - input_.rfind('\n', 0, pos)
+
 
 class Parser(object):
 
@@ -98,17 +101,17 @@ class Parser(object):
 
     def __init__(self):
         self._init_parse_data()
-        self.lexer = lex.lex(module = self, debug = 0)
-        self.yacc = yacc.yacc(module = self, tabmodule = 'parsetab_prophy', write_tables = 0, debug = 0)
+        self.lexer = lex.lex(module=self, debug=0)
+        self.yacc = yacc.yacc(module=self, tabmodule='parsetab_prophy', write_tables=0, debug=0)
 
-    def parse(self, input, parse_error_prefix, parse_file):
+    def parse(self, input_, parse_error_prefix, parse_file):
         self._init_parse_data(parse_error_prefix)
         self.parse_file = parse_file
         self.lexer.lineno = 1
-        self.yacc.parse(input, lexer = self.lexer)
+        self.yacc.parse(input_, lexer=self.lexer)
         return self.nodes
 
-    def _init_parse_data(self, parse_error_prefix = ""):
+    def _init_parse_data(self, parse_error_prefix=""):
         self.nodes = []
         self.typedecls = {}
         self.constdecls = {}
@@ -237,7 +240,7 @@ class Parser(object):
 
     def p_typedef_def(self, t):
         '''typedef_def : TYPEDEF type_spec unique_id SEMI'''
-        node = Typedef(t[3], t[2][0], definition = t[2][1])
+        node = Typedef(t[3], t[2][0], definition=t[2][1])
         self.typedecls[t[3]] = node
         self.nodes.append(node)
 
@@ -264,44 +267,45 @@ class Parser(object):
 
     def p_struct_member_1(self, t):
         '''struct_member : type_spec ID'''
-        t[0] = [(StructMember(t[2], t[1][0], definition = t[1][1]), t.lineno(2), t.lexpos(2))]
+        t[0] = [(StructMember(t[2], t[1][0], definition=t[1][1]), t.lineno(2), t.lexpos(2))]
 
     def p_struct_member_2(self, t):
         '''struct_member : bytes ID LBRACKET positive_expression RBRACKET
                          | type_spec ID LBRACKET positive_expression RBRACKET'''
-        t[0] = [(StructMember(t[2], t[1][0], size = str(t[4]), definition = t[1][1]), t.lineno(2), t.lexpos(2))]
+        t[0] = [(StructMember(t[2], t[1][0], size=str(t[4]), definition=t[1][1]), t.lineno(2), t.lexpos(2))]
 
     def p_struct_member_3(self, t):
         '''struct_member : bytes ID LT AT ID GT
                          | type_spec ID LT AT ID GT'''
         t[0] = [
-            (StructMember(t[2], t[1][0], bound = t[5], definition = t[1][1]), t.lineno(2), t.lexpos(2))
+            (StructMember(t[2], t[1][0], bound=t[5], definition=t[1][1]), t.lineno(2), t.lexpos(2))
         ]
 
     def p_struct_member_4(self, t):
         '''struct_member : bytes ID LT GT
                          | type_spec ID LT GT'''
         t[0] = [
-            (StructMember('num_of_' + t[2], 'u32', definition = None), t.lineno(2), t.lexpos(2)),
-            (StructMember(t[2], t[1][0], bound = 'num_of_' + t[2], definition = t[1][1]), t.lineno(2), t.lexpos(2))
+            (StructMember('num_of_' + t[2], 'u32', definition=None), t.lineno(2), t.lexpos(2)),
+            (StructMember(t[2], t[1][0], bound='num_of_' + t[2], definition=t[1][1]), t.lineno(2), t.lexpos(2))
         ]
 
     def p_struct_member_5(self, t):
         '''struct_member : bytes ID LT positive_expression GT
                          | type_spec ID LT positive_expression GT'''
         t[0] = [
-            (StructMember('num_of_' + t[2], 'u32', definition = None), t.lineno(2), t.lexpos(2)),
-            (StructMember(t[2], t[1][0], bound = 'num_of_' + t[2], size = str(t[4]), definition = t[1][1]), t.lineno(2), t.lexpos(2))
+            (StructMember('num_of_' + t[2], 'u32', definition=None), t.lineno(2), t.lexpos(2)),
+            (StructMember(t[2], t[1][0], bound='num_of_' + t[2],
+                          size=str(t[4]), definition=t[1][1]), t.lineno(2), t.lexpos(2))
         ]
 
     def p_struct_member_6(self, t):
         '''struct_member : bytes ID LT DOTS GT
                          | type_spec ID LT DOTS GT'''
-        t[0] = [(StructMember(t[2], t[1][0], unlimited = True, definition = t[1][1]), t.lineno(2), t.lexpos(2))]
+        t[0] = [(StructMember(t[2], t[1][0], unlimited=True, definition=t[1][1]), t.lineno(2), t.lexpos(2))]
 
     def p_struct_member_7(self, t):
         '''struct_member : type_spec '*' ID'''
-        t[0] = [(StructMember(t[3], t[1][0], optional = True, definition = t[1][1]), t.lineno(3), t.lexpos(3))]
+        t[0] = [(StructMember(t[3], t[1][0], optional=True, definition=t[1][1]), t.lineno(3), t.lexpos(3))]
 
     def p_bytes(self, t):
         '''bytes : BYTES'''
@@ -351,7 +355,7 @@ class Parser(object):
 
     def p_union_member(self, t):
         '''union_member : expression COLON type_spec ID'''
-        t[0] = (UnionMember(t[4], t[3][0], str(t[1]), definition = t[3][1]), t.lineno(4), t.lexpos(4))
+        t[0] = (UnionMember(t[4], t[3][0], str(t[1]), definition=t[3][1]), t.lineno(4), t.lexpos(4))
 
     def p_type_spec_1(self, t):
         '''type_spec : U8
@@ -407,12 +411,18 @@ class Parser(object):
                       | expression LSHIFT expression
                       | expression RSHIFT expression'''
         try:
-            if t[2] == '+': t[0] = t[1] + t[3]
-            elif t[2] == '-': t[0] = t[1] - t[3]
-            elif t[2] == '*': t[0] = t[1] * t[3]
-            elif t[2] == '/': t[0] = t[1] / t[3]
-            elif t[2] == '<<': t[0] = t[1] << t[3]
-            elif t[2] == '>>': t[0] = t[1] >> t[3]
+            if t[2] == '+':
+                t[0] = t[1] + t[3]
+            elif t[2] == '-':
+                t[0] = t[1] - t[3]
+            elif t[2] == '*':
+                t[0] = t[1] * t[3]
+            elif t[2] == '/':
+                t[0] = t[1] / t[3]
+            elif t[2] == '<<':
+                t[0] = t[1] << t[3]
+            elif t[2] == '>>':
+                t[0] = t[1] >> t[3]
         except ZeroDivisionError:
             self._parser_error(
                 'division by zero',
@@ -474,8 +484,9 @@ class Parser(object):
             pos = len(self.lexer.lexdata) - 1
         self._parser_error(message, line, pos)
 
+
 @contextmanager
-def allocate_parser(parsers = []):
+def allocate_parser(parsers=[]):
     """
     Creating parsers is very expensive, so there is a need to reuse them.
     On the other hand, recursive parser usage requires a unique one for each
@@ -488,12 +499,14 @@ def allocate_parser(parsers = []):
     finally:
         parsers.append(parser)
 
-def build_model(input, parse_error_prefix, parse_file):
+
+def build_model(input_, parse_error_prefix, parse_file):
     with allocate_parser() as parser:
-        parser.parse(input, parse_error_prefix, parse_file)
+        parser.parse(input_, parse_error_prefix, parse_file)
         if parser.errors:
             raise ParseError(parser.errors)
         return parser.nodes
+
 
 class ProphyParser(object):
 

--- a/prophyc/parsers/sack.py
+++ b/prophyc/parsers/sack.py
@@ -8,8 +8,10 @@ from prophyc.generators.cpp import _generate_def_enum
 from prophyc.six import to_bytes
 from contextlib import contextmanager
 
+
 class SackParserError(Exception):
     pass
+
 
 class SackModelTree(object):
     def __init__(self):
@@ -23,6 +25,7 @@ class SackModelTree(object):
     def remove_nodes(self, node_names_to_remove):
         self.nodes = [node for node in self.nodes if node.name not in node_names_to_remove]
         self.known -= set(node_names_to_remove)
+
 
 class Builder(object):
     unambiguous_builtins = {
@@ -146,6 +149,7 @@ class Builder(object):
                 if cursor.kind is CursorKind.ENUM_DECL:
                     self.add_enum(cursor)
 
+
 class SupplementaryDefs(object):
 
     def __init__(self, include_tree):
@@ -210,7 +214,7 @@ class SackParser(object):
     @staticmethod
     def check():
         class SackParserStatus(object):
-            def __init__(self, error = None):
+            def __init__(self, error=None):
                 self.error = error
 
             def __bool__(self):

--- a/prophyc/patch.py
+++ b/prophyc/patch.py
@@ -3,6 +3,7 @@ from . import model
 
 Action = namedtuple("Action", ["action", "params"])
 
+
 def parse(filename):
     def make_item(line):
         words = line.split()
@@ -14,11 +15,13 @@ def parse(filename):
         patches.setdefault(name, []).append(action)
     return patches
 
+
 def patch(nodes, patchdict):
     for idx, node in enumerate(nodes):
         patches = patchdict.get(node.name)
         if patches:
             nodes[idx] = _apply(node, patches)
+
 
 def _apply(node, patches):
     for patch in patches:
@@ -27,6 +30,7 @@ def _apply(node, patches):
             raise Exception("Unknown action: %s %s" % (node.name, patch))
         node = action(node, patch)
     return node
+
 
 def _type(node, patch):
     if not isinstance(node, model.Struct):
@@ -44,6 +48,7 @@ def _type(node, patch):
     mem.type_ = tp
     return node
 
+
 def _insert(node, patch):
     if not isinstance(node, model.Struct):
         raise Exception("Can insert field only in struct: %s %s" % (node.name, patch))
@@ -59,6 +64,7 @@ def _insert(node, patch):
     node.members.insert(index, model.StructMember(name, tp))
     return node
 
+
 def _remove(node, patch):
     if not isinstance(node, model.Struct):
         raise Exception("Can remove field only in struct: %s %s" % (node.name, patch))
@@ -73,6 +79,7 @@ def _remove(node, patch):
 
     del node.members[i]
     return node
+
 
 def _dynamic(node, patch):
     if not isinstance(node, model.Struct):
@@ -93,6 +100,7 @@ def _dynamic(node, patch):
     mem.optional = False
     return node
 
+
 def _greedy(node, patch):
     if not isinstance(node, model.Struct):
         raise Exception("Can change field only in struct: %s %s" % (node.name, patch))
@@ -111,6 +119,7 @@ def _greedy(node, patch):
     mem.size = None
     mem.optional = False
     return node
+
 
 def _static(node, patch):
     if not isinstance(node, model.Struct):
@@ -134,6 +143,7 @@ def _static(node, patch):
     mem.optional = False
     return node
 
+
 def _limited(node, patch):
     if not isinstance(node, model.Struct):
         raise Exception("Can change field only in struct: %s %s" % (node.name, patch))
@@ -156,6 +166,7 @@ def _limited(node, patch):
     mem.optional = False
     return node
 
+
 def _struct(node, patch):
     if not isinstance(node, model.Union):
         raise Exception("Can only change union to struct: %s" % (node.name))
@@ -164,9 +175,10 @@ def _struct(node, patch):
         raise Exception("Change union to struct takes no params: %s" % (node.name))
 
     def to_struct_member(member):
-        return model.StructMember(name = member.name, type_ = member.type_, definition = member.definition)
+        return model.StructMember(name=member.name, type_=member.type_, definition=member.definition)
 
     return model.Struct(node.name, [to_struct_member(mem) for mem in node.members])
+
 
 def _rename(node, patch):
     def rename_node(node, new_name):
@@ -200,6 +212,7 @@ _actions = {'type': _type,
             'dynamic': _dynamic,
             'struct': _struct,
             'rename': _rename}
+
 
 def _is_int(s):
     try:

--- a/prophyc/patch.py
+++ b/prophyc/patch.py
@@ -152,8 +152,8 @@ def _limited(node, patch):
         raise Exception("Change field must have 2 params: %s %s" % (node.name, patch))
     name, len_array = patch.params
 
-    i, member = next((x for x in enumerate(node.members) if x[1].name == len_array), (None, None))
-    if not member:
+    sizer_found = len(tuple(x for x in node.members if x.name == len_array))
+    if not sizer_found:
         raise Exception("Array len member not found: %s %s" % (node.name, patch))
 
     i, member = next((x for x in enumerate(node.members) if x[1].name == name), (None, None))
@@ -188,7 +188,7 @@ def _rename(node, patch):
     def rename_field(node, orig_name, new_name):
         if not isinstance(node, (model.Struct, model.Union)):
             raise Exception("Can rename fields only in composites: %s %s" % (node.name, patch))
-        i, member = next((x for x in enumerate(node.members) if x[1].name == orig_name), (None, None))
+        member = next((x for x in node.members if x.name == orig_name), None)
         if not member:
             raise Exception("Member not found: %s %s" % (node.name, patch))
         member.name = new_name

--- a/prophyc/six.py
+++ b/prophyc/six.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version < '3':
+if sys.version < '3':  # pragma: no cover
     from itertools import ifilter
     reduce = reduce
     string_types = (str, unicode)
@@ -8,7 +8,7 @@ if sys.version < '3':
     def to_bytes(str_):
         return str_
 
-else:
+else:  # pragma: no cover
     ifilter = filter
     from functools import reduce
     string_types = str

--- a/prophyc/six.py
+++ b/prophyc/six.py
@@ -4,6 +4,7 @@ if sys.version < '3':
     from itertools import ifilter
     reduce = reduce
     string_types = (str, unicode)
+
     def to_bytes(str_):
         return str_
 
@@ -11,5 +12,6 @@ else:
     ifilter = filter
     from functools import reduce
     string_types = str
+
     def to_bytes(str_):
         return bytes(str_, 'utf-8')

--- a/prophyc/tests/conftest.py
+++ b/prophyc/tests/conftest.py
@@ -9,15 +9,18 @@ import prophyc
 main_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.insert(0, main_dir)
 
+
 def check_libclang():
     from prophyc.parsers.sack import SackParser
     return SackParser.check()
 
+
 def pytest_namespace():
     return {
-        'clang_installed': pytest.mark.skipif(not check_libclang(), reason = "clang not installed"),
-        'clang_not_installed': pytest.mark.skipif(check_libclang(), reason = "clang installed")
+        'clang_installed': pytest.mark.skipif(not check_libclang(), reason="clang not installed"),
+        'clang_not_installed': pytest.mark.skipif(check_libclang(), reason="clang installed")
     }
+
 
 @pytest.yield_fixture
 def tmpdir_cwd(tmpdir):
@@ -28,11 +31,13 @@ def tmpdir_cwd(tmpdir):
     sys.path.pop(0)
     os.chdir(orig_dir)
 
+
 @pytest.yield_fixture
 def tmpfiles_cwd(tmpdir_cwd):
     def create_tmp_files(*files_to_create):
         return map(tmpdir_cwd.join, files_to_create)
     yield create_tmp_files
+
 
 @pytest.fixture
 def dummy_file(tmpdir_cwd):
@@ -61,6 +66,7 @@ def sys_capture(capsys):
         def get(self):
             return self.code, self.out, self.err
     return Capture
+
 
 @pytest.fixture(params=["subprocess", "py_code"])
 def call_prophyc(request, sys_capture):

--- a/prophyc/tests/generators/test_cpp.py
+++ b/prophyc/tests/generators/test_cpp.py
@@ -2,6 +2,7 @@ import pytest
 from prophyc import model
 from prophyc.generators.cpp import CppGenerator, GenerateError, _Padder, _check_nodes
 
+
 def process(nodes):
     model.cross_reference(nodes)
     model.evaluate_kinds(nodes)
@@ -9,20 +10,26 @@ def process(nodes):
     _check_nodes(nodes)
     return nodes
 
+
 def generate_definitions(nodes):
     return CppGenerator().generate_definitions(nodes)
+
 
 def generate_swap_declarations(nodes):
     return CppGenerator().generate_swap_declarations(nodes)
 
+
 def generate_swap(nodes):
     return CppGenerator().generate_swap(nodes)
+
 
 def generate_hpp(nodes, basename):
     return CppGenerator().serialize_string_hpp(nodes, basename)
 
+
 def generate_cpp(nodes, basename):
     return CppGenerator().serialize_string_cpp(nodes, basename)
+
 
 def test_padder_indexing():
     padder = _Padder()
@@ -34,12 +41,14 @@ def test_padder_indexing():
     assert (padder.generate_padding(1) ==
             'uint8_t _padding2; /// manual padding to ensure natural alignment layout\n')
 
+
 def test_padder_non_pow2():
     padder = _Padder()
 
     assert (padder.generate_padding(5) ==
             ('uint8_t _padding0; /// manual padding to ensure natural alignment layout\n'
              'uint32_t _padding1; /// manual padding to ensure natural alignment layout\n'))
+
 
 def test_definitions_includes():
     nodes = process([
@@ -53,6 +62,7 @@ def test_definitions_includes():
 #include "mydlo.pp.hpp"
 #include "powidlo.pp.hpp"
 """
+
 
 def test_definitions_constants():
     nodes = process([
@@ -69,6 +79,7 @@ enum { CONST_B = 0x123u };
 enum { CONST_B = 0o741u };
 """
 
+
 def test_definitions_typedefs():
     nodes = process([
         model.Typedef("a", "b"),
@@ -79,6 +90,7 @@ def test_definitions_typedefs():
 typedef b a;
 typedef uint8_t c;
 """
+
 
 def test_definitions_enums():
     nodes = process([
@@ -99,6 +111,7 @@ enum EEnum
     EEnum_D = abc
 };
 """
+
 
 def test_definitions_struct():
     nodes = process([
@@ -124,12 +137,13 @@ PROPHY_STRUCT(8) Struct
 };
 """
 
+
 def test_definitions_struct_with_dynamic_array():
     nodes = process([
         model.Typedef('TNumberOfItems', 'u32'),
         model.Struct("Struct", [
             model.StructMember("tmpName", "TNumberOfItems"),
-            model.StructMember("a", "u8", bound = "tmpName")
+            model.StructMember("a", "u8", bound="tmpName")
         ])
     ])
 
@@ -141,10 +155,11 @@ PROPHY_STRUCT(4) Struct
 };
 """
 
+
 def test_definitions_struct_with_fixed_array():
     nodes = process([
         model.Constant("NUM_OF_ARRAY_ELEMS", "3"),
-        model.Struct("Struct", [model.StructMember("a", "u8", size = "NUM_OF_ARRAY_ELEMS")])
+        model.Struct("Struct", [model.StructMember("a", "u8", size="NUM_OF_ARRAY_ELEMS")])
     ])
 
     assert generate_definitions(nodes[-1:]) == """\
@@ -154,12 +169,13 @@ PROPHY_STRUCT(1) Struct
 };
 """
 
+
 def test_definitions_struct_with_limited_array():
     nodes = process([
         model.Constant('NUM_OF_ARRAY_ELEMS', '1'),
         model.Struct("Struct", [
             model.StructMember("a_len", "u8"),
-            model.StructMember("a", "u8", bound = "a_len", size = "NUM_OF_ARRAY_ELEMS")
+            model.StructMember("a", "u8", bound="a_len", size="NUM_OF_ARRAY_ELEMS")
         ])
     ])
 
@@ -171,13 +187,14 @@ PROPHY_STRUCT(1) Struct
 };
 """
 
+
 def test_definitions_struct_with_ext_sized_array():
     nodes = process([
         model.Struct("Struct", [
             model.StructMember("count", "u8"),
-            model.StructMember("a", "u8", bound = "count"),
-            model.StructMember("b", "u8", bound = "count"),
-            model.StructMember("c", "u8", bound = "count")
+            model.StructMember("a", "u8", bound="count"),
+            model.StructMember("b", "u8", bound="count"),
+            model.StructMember("c", "u8", bound="count")
         ])
     ])
 
@@ -199,6 +216,7 @@ PROPHY_STRUCT(1) Struct
 };
 """
 
+
 def test_definitions_struct_with_byte():
     nodes = process([
         model.Struct("Struct", [model.StructMember("a", "byte")])
@@ -211,9 +229,10 @@ PROPHY_STRUCT(1) Struct
 };
 """
 
+
 def test_definitions_struct_with_byte_array():
     nodes = process([
-        model.Struct("Struct", [model.StructMember("a", "byte", unlimited = True)])
+        model.Struct("Struct", [model.StructMember("a", "byte", unlimited=True)])
     ])
 
     assert generate_definitions(nodes) == """\
@@ -223,15 +242,16 @@ PROPHY_STRUCT(1) Struct
 };
 """
 
+
 def test_definitions_struct_many_arrays():
     nodes = process([
         model.Struct("ManyArrays", [
             model.StructMember("num_of_a", "u8"),
-            model.StructMember("a", "u8", bound = "num_of_a"),
+            model.StructMember("a", "u8", bound="num_of_a"),
             model.StructMember("num_of_b", "u8"),
-            model.StructMember("b", "u8", bound = "num_of_b"),
+            model.StructMember("b", "u8", bound="num_of_b"),
             model.StructMember("num_of_c", "u8"),
-            model.StructMember("c", "u8", bound = "num_of_c")
+            model.StructMember("c", "u8", bound="num_of_c")
         ])
     ])
 
@@ -255,13 +275,14 @@ PROPHY_STRUCT(1) ManyArrays
 };
 """
 
+
 def test_definitions_struct_many_arrays_mixed():
     nodes = process([
         model.Struct("ManyArraysMixed", [
             model.StructMember("num_of_a", "u8"),
             model.StructMember("num_of_b", "u8"),
-            model.StructMember("a", "u8", bound = "num_of_a"),
-            model.StructMember("b", "u8", bound = "num_of_b")
+            model.StructMember("a", "u8", bound="num_of_a"),
+            model.StructMember("b", "u8", bound="num_of_b")
         ])
     ])
 
@@ -279,13 +300,14 @@ PROPHY_STRUCT(1) ManyArraysMixed
 };
 """
 
+
 def test_definitions_struct_many_arrays_bounded_by_the_same_member():
     nodes = process([
         model.Struct("ManyArraysBoundedByTheSame", [
             model.StructMember("num_of_elements", "u8"),
             model.StructMember("dummy", "u8"),
-            model.StructMember("a", "u8", bound = "num_of_elements"),
-            model.StructMember("b", "u8", bound = "num_of_elements")
+            model.StructMember("a", "u8", bound="num_of_elements"),
+            model.StructMember("b", "u8", bound="num_of_elements")
         ])
     ])
 
@@ -303,11 +325,12 @@ PROPHY_STRUCT(1) ManyArraysBoundedByTheSame
 };
 """
 
+
 def test_definitions_struct_with_dynamic_fields():
     nodes = process([
         model.Struct("Dynamic", [
             model.StructMember("num_of_a", "u8"),
-            model.StructMember("a", "u8", bound = "num_of_a")
+            model.StructMember("a", "u8", bound="num_of_a")
         ]),
         model.Struct("X", [
             model.StructMember("a", "u8"),
@@ -329,10 +352,11 @@ PROPHY_STRUCT(1) X
 };
 """
 
+
 def test_definitions_struct_with_optional_field():
     nodes = process([
         model.Struct("Struct", [
-            (model.StructMember("a", "u8", optional = True))
+            (model.StructMember("a", "u8", optional=True))
         ])
     ])
 
@@ -346,11 +370,12 @@ PROPHY_STRUCT(4) Struct
 };
 """
 
+
 def test_definitions_struct_padding():
     nodes = process([
         model.Struct("B", [
             model.StructMember("num_of_a", "u16"),
-            model.StructMember("a", "u8", bound = "num_of_a")
+            model.StructMember("a", "u8", bound="num_of_a")
         ]),
         model.Struct("C", [
             model.StructMember("a", "u16")
@@ -361,7 +386,7 @@ def test_definitions_struct_padding():
             model.StructMember("c", "C"),
             model.StructMember("d", "u32"),
             model.StructMember("num_of_e", "u32"),
-            model.StructMember("e", "u64", bound = "num_of_e"),
+            model.StructMember("e", "u64", bound="num_of_e"),
             model.StructMember("f", "u8")
         ])
     ])
@@ -389,6 +414,7 @@ PROPHY_STRUCT(8) X
     } _3;
 };
 """
+
 
 def test_definitions_union():
     nodes = process([
@@ -441,6 +467,7 @@ PROPHY_STRUCT(8) UnionPadded
 };
 """
 
+
 def test_definitions_newlines():
     nodes = process([
         model.Typedef("a", "b"),
@@ -487,6 +514,7 @@ PROPHY_STRUCT(4) B
 };
 """
 
+
 def test_swap_empty_struct():
     nodes = process([
         model.Struct("X", [])
@@ -499,6 +527,7 @@ X* swap<X>(X* payload)
     return payload + 1;
 }
 """
+
 
 def test_swap_struct_with_fixed_element():
     nodes = process([
@@ -516,12 +545,13 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_optional_element():
     nodes = process([
         model.Typedef('Y', 'u32'),
         model.Struct("X", [
-            (model.StructMember("x", "u32", optional = True)),
-            (model.StructMember("y", "Y", optional = True))
+            (model.StructMember("x", "u32", optional=True)),
+            (model.StructMember("y", "Y", optional=True))
         ])
     ])
 
@@ -536,6 +566,7 @@ X* swap<X>(X* payload)
     return payload + 1;
 }
 """
+
 
 def test_swap_union():
     nodes = process([
@@ -563,10 +594,11 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_fixed_array_of_fixed_elements():
     nodes = process([
         model.Struct("X", [
-            (model.StructMember("x", "u16", size = 5))
+            (model.StructMember("x", "u16", size=5))
         ])
     ])
 
@@ -579,12 +611,13 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_limited_array_of_fixed_elements():
     nodes = process([
         model.Typedef('Y', 'u32'),
         model.Struct("X", [
             (model.StructMember("num_of_x", "u16")),
-            (model.StructMember("x", "Y", bound = "num_of_x", size = 3))
+            (model.StructMember("x", "Y", bound="num_of_x", size=3))
         ])
     ])
 
@@ -598,11 +631,12 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_dynamic_array_of_fixed_elements():
     nodes = process([
         model.Struct("X", [
             (model.StructMember("num_of_x", "u32")),
-            (model.StructMember("x", "u16", bound = "num_of_x"))
+            (model.StructMember("x", "u16", bound="num_of_x"))
         ])
     ])
 
@@ -615,12 +649,13 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_ext_sized_array_of_fixed_elements():
     nodes = process([
         model.Struct("X", [
             (model.StructMember("szr", "u32")),
-            (model.StructMember("x", "u16", bound = "szr")),
-            (model.StructMember("y", "u16", bound = "szr"))
+            (model.StructMember("x", "u16", bound="szr")),
+            (model.StructMember("y", "u16", bound="szr"))
         ])
     ])
 
@@ -639,13 +674,14 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_greedy_array():
     nodes = process([
         model.Typedef('X', 'u32'),
         model.Typedef('Y', 'u32'),
         model.Struct("X", [
             (model.StructMember("x", "u8")),
-            (model.StructMember("y", "Y", unlimited = True))
+            (model.StructMember("y", "Y", unlimited=True))
         ]),
         model.Struct("Z", [
             (model.StructMember("z", "X"))
@@ -667,6 +703,7 @@ Z* swap<Z>(Z* payload)
 }
 """
 
+
 def test_swap_enum_in_struct():
     nodes = process([
         model.Enum("E1", [
@@ -686,17 +723,18 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_enum_in_arrays():
     nodes = process([
         model.Enum("E1", [
             model.EnumMember("E1_A", "0")
         ]),
         model.Struct("EnumArrays", [
-            (model.StructMember("a", "E1", size = 2)),
+            (model.StructMember("a", "E1", size=2)),
             (model.StructMember("num_of_b", "u32")),
-            (model.StructMember("b", "E1", size = 2, bound = "num_of_b")),
+            (model.StructMember("b", "E1", size=2, bound="num_of_b")),
             (model.StructMember("num_of_c", "u32")),
-            (model.StructMember("c", "E1", bound = "num_of_c"))
+            (model.StructMember("c", "E1", bound="num_of_c"))
         ])
     ])
 
@@ -712,13 +750,14 @@ EnumArrays* swap<EnumArrays>(EnumArrays* payload)
 }
 """
 
+
 def test_swap_enum_in_greedy_array():
     nodes = process([
         model.Enum("E1", [
             model.EnumMember("E1_A", "0")
         ]),
         model.Struct("EnumGreedyArray", [
-            (model.StructMember("x", "E1", unlimited = True))
+            (model.StructMember("x", "E1", unlimited=True))
         ])
     ])
 
@@ -729,6 +768,7 @@ EnumGreedyArray* swap<EnumGreedyArray>(EnumGreedyArray* payload)
     return cast<EnumGreedyArray*>(payload->x);
 }
 """
+
 
 def test_swap_enum_in_union():
     nodes = process([
@@ -754,11 +794,12 @@ EnumUnion* swap<EnumUnion>(EnumUnion* payload)
 }
 """
 
+
 def test_swap_struct_with_dynamic_element():
     nodes = process([
         model.Struct("Dynamic", [
             (model.StructMember("num_of_x", "u32")),
-            (model.StructMember("x", "u16", bound = "num_of_x"))
+            (model.StructMember("x", "u16", bound="num_of_x"))
         ]),
         model.Struct("X", [
             (model.StructMember("a", "Dynamic"))
@@ -780,15 +821,16 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_dynamic_array_of_dynamic_elements():
     nodes = process([
         model.Struct("Y", [
             (model.StructMember("num_of_x", "u32")),
-            (model.StructMember("x", "u16", bound = "num_of_x"))
+            (model.StructMember("x", "u16", bound="num_of_x"))
         ]),
         model.Struct("X", [
             (model.StructMember("num_of_x", "u32")),
-            (model.StructMember("x", "Y", bound = "num_of_x"))
+            (model.StructMember("x", "Y", bound="num_of_x"))
         ])
     ])
 
@@ -808,15 +850,16 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_many_arrays():
     nodes = process([
         model.Struct("X", [
             (model.StructMember("num_of_x", "u32")),
-            (model.StructMember("x", "u32", bound = "num_of_x")),
+            (model.StructMember("x", "u32", bound="num_of_x")),
             (model.StructMember("num_of_y", "u32")),
-            (model.StructMember("y", "u32", bound = "num_of_y")),
+            (model.StructMember("y", "u32", bound="num_of_y")),
             (model.StructMember("num_of_z", "u32")),
-            (model.StructMember("z", "u32", bound = "num_of_z"))
+            (model.StructMember("z", "u32", bound="num_of_z"))
         ])
     ])
 
@@ -843,13 +886,14 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_many_arrays_bounded_by_the_same_member():
     nodes = process([
         model.Struct("X", [
             (model.StructMember("num_of_elements", "u32")),
             (model.StructMember("dummy", "u32")),
-            (model.StructMember("x", "u32", bound = "num_of_elements")),
-            (model.StructMember("y", "u32", bound = "num_of_elements"))
+            (model.StructMember("x", "u32", bound="num_of_elements")),
+            (model.StructMember("y", "u32", bound="num_of_elements"))
         ])
     ])
 
@@ -869,13 +913,14 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_many_arrays_passing_numbering_fields():
     nodes = process([
         model.Struct("X", [
             (model.StructMember("num_of_x", "u32")),
             (model.StructMember("num_of_y", "u32")),
-            (model.StructMember("x", "u32", bound = "num_of_x")),
-            (model.StructMember("y", "u32", bound = "num_of_y"))
+            (model.StructMember("x", "u32", bound="num_of_x")),
+            (model.StructMember("y", "u32", bound="num_of_y"))
         ])
     ])
 
@@ -895,15 +940,16 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_many_arrays_passing_numbering_fields_heavily():
     nodes = process([
         model.Struct("X", [
             (model.StructMember("num_of_a", "u32")),
             (model.StructMember("num_of_b", "u32")),
-            (model.StructMember("b", "u16", bound = "num_of_b")),
+            (model.StructMember("b", "u16", bound="num_of_b")),
             (model.StructMember("num_of_c", "u32")),
-            (model.StructMember("c", "u16", bound = "num_of_c")),
-            (model.StructMember("a", "u16", bound = "num_of_a"))
+            (model.StructMember("c", "u16", bound="num_of_c")),
+            (model.StructMember("a", "u16", bound="num_of_a"))
         ])
     ])
 
@@ -930,11 +976,12 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_dynamic_field_and_tail_fixed():
     nodes = process([
         model.Struct("X", [
             (model.StructMember("num_of_x", "u8")),
-            (model.StructMember("x", "u8", bound = "num_of_x")),
+            (model.StructMember("x", "u8", bound="num_of_x")),
             (model.StructMember("y", "u32")),
             (model.StructMember("z", "u64"))
         ])
@@ -957,11 +1004,12 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_swap_struct_with_many_dynamic_fields():
     nodes = process([
         model.Struct("Y", [
             (model.StructMember("num_of_x", "u32")),
-            (model.StructMember("x", "u16", bound = "num_of_x"))
+            (model.StructMember("x", "u16", bound="num_of_x"))
         ]),
         model.Struct("X", [
             (model.StructMember("x", "Y")),
@@ -997,6 +1045,7 @@ X* swap<X>(X* payload)
 }
 """
 
+
 def test_generate_swap_declarations():
     nodes = process([
         model.Struct("A", [
@@ -1020,6 +1069,7 @@ template <> B* swap<B>(B*);
 
 } // namespace prophy
 """
+
 
 def test_generate_empty_file():
     assert generate_hpp([], "TestEmpty") == """\
@@ -1051,6 +1101,7 @@ namespace prophy
 
 } // namespace prophy
 """
+
 
 def test_generate_file():
     nodes = process([
@@ -1099,6 +1150,7 @@ Struct* swap<Struct>(Struct* payload)
 
 } // namespace prophy
 """
+
 
 def test_struct_size_error():
     nodes = [

--- a/prophyc/tests/generators/test_cpp_full.py
+++ b/prophyc/tests/generators/test_cpp_full.py
@@ -31,26 +31,32 @@ from prophyc.generators.cpp_full import (
     CppFullGenerator
 )
 
+# flake8: noqa E501
+
+
 def process(nodes):
     model.cross_reference(nodes)
     model.evaluate_kinds(nodes)
     model.evaluate_sizes(nodes)
     return nodes
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Include():
     return process([
         model.Include('Arrays', [])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Constant():
     return process([
         model.Constant('CONSTANT', '3'),
         model.Constant('CONSTANT_WITH_IDENTIFIER', 'xyz')
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Enum():
     return process([
         model.Enum('Enum', [
@@ -61,14 +67,16 @@ def Enum():
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Typedef():
     return process([
         model.Typedef('TU16', 'u16'),
         model.Typedef('TX', 'X')
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Struct():
     return process([
         model.Struct('X', [
@@ -77,11 +85,12 @@ def Struct():
         ]),
         model.Struct('Y', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'X', bound = 'num_of_x')
+            model.StructMember('x', 'X', bound='num_of_x')
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Union():
     return process([
         model.Union('X', [
@@ -89,10 +98,12 @@ def Union():
         ])
     ])
 
+
 def test_generate_include_definition(Include):
     assert generate_include_definition(Include[0]) == """\
 #include "Arrays.ppf.hpp"
 """
+
 
 def test_generate_constant_definition(Constant):
     assert generate_constant_definition(Constant[0]) == """\
@@ -101,6 +112,7 @@ enum { CONSTANT = 3u };
     assert generate_constant_definition(Constant[1]) == """\
 enum { CONSTANT_WITH_IDENTIFIER = xyz };
 """
+
 
 def test_generate_enum_definition(Enum):
     assert generate_enum_definition(Enum[0]) == """\
@@ -113,6 +125,7 @@ enum Enum
 };
 """
 
+
 def test_generate_typedef_definition(Typedef):
     assert generate_typedef_definition(Typedef[0]) == """\
 typedef uint16_t TU16;
@@ -120,6 +133,7 @@ typedef uint16_t TU16;
     assert generate_typedef_definition(Typedef[1]) == """\
 typedef X TX;
 """
+
 
 def test_generate_struct_definition(Struct):
     assert generate_struct_definition(Struct[0]) == """\
@@ -156,6 +170,7 @@ struct Y : public prophy::detail::message<Y>
 };
 """
 
+
 def test_generate_union_definition(Union):
     assert generate_union_definition(Union[0]) == """\
 struct X : public prophy::detail::message<X>
@@ -181,6 +196,7 @@ struct X : public prophy::detail::message<X>
 };
 """
 
+
 def test_generate_enum_implementation(Enum):
     assert generate_enum_implementation(Enum[0]) == """\
 template <>
@@ -196,6 +212,7 @@ const char* print_traits<Enum>::to_literal(Enum x)
     }
 }
 """
+
 
 def test_generate_struct_implementation(Struct):
     assert generate_struct_implementation(Struct[0]) == """\
@@ -266,6 +283,7 @@ void message_impl<Y>::print(const Y& x, std::ostream& out, size_t indent)
 template void message_impl<Y>::print(const Y& x, std::ostream& out, size_t indent);
 """
 
+
 def test_generate_union_implementation(Union):
     assert generate_union_implementation(Union[0]) == """\
 template <>
@@ -311,7 +329,8 @@ void message_impl<X>::print(const X& x, std::ostream& out, size_t indent)
 template void message_impl<X>::print(const X& x, std::ostream& out, size_t indent);
 """
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Builtin():
     return process([
         model.Struct('Builtin', [
@@ -319,22 +338,23 @@ def Builtin():
             model.StructMember('y', 'u32')
         ]),
         model.Struct('BuiltinFixed', [
-            model.StructMember('x', 'u32', size = 2)
+            model.StructMember('x', 'u32', size=2)
         ]),
         model.Struct('BuiltinDynamic', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u32', bound = 'num_of_x')
+            model.StructMember('x', 'u32', bound='num_of_x')
         ]),
         model.Struct('BuiltinLimited', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u32', size = 2, bound = 'num_of_x')
+            model.StructMember('x', 'u32', size=2, bound='num_of_x')
         ]),
         model.Struct('BuiltinGreedy', [
-            model.StructMember('x', 'u32', unlimited = True)
+            model.StructMember('x', 'u32', unlimited=True)
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Fixcomp():
     return process([
         model.Struct('Builtin', [
@@ -346,41 +366,43 @@ def Fixcomp():
             model.StructMember('y', 'Builtin')
         ]),
         model.Struct('FixcompFixed', [
-            model.StructMember('x', 'Builtin', size = 2)
+            model.StructMember('x', 'Builtin', size=2)
         ]),
         model.Struct('FixcompDynamic', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'Builtin', bound = 'num_of_x')
+            model.StructMember('x', 'Builtin', bound='num_of_x')
         ]),
         model.Struct('FixcompLimited', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'Builtin', size = 2, bound = 'num_of_x')
+            model.StructMember('x', 'Builtin', size=2, bound='num_of_x')
         ]),
         model.Struct('FixcompGreedy', [
-            model.StructMember('x', 'Builtin', unlimited = True)
+            model.StructMember('x', 'Builtin', unlimited=True)
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Dyncomp():
     return process([
         model.Struct('BuiltinDynamic', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u32', bound = 'num_of_x')
+            model.StructMember('x', 'u32', bound='num_of_x')
         ]),
         model.Struct('Dyncomp', [
             model.StructMember('x', 'BuiltinDynamic')
         ]),
         model.Struct('DyncompDynamic', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'BuiltinDynamic', bound = 'num_of_x')
+            model.StructMember('x', 'BuiltinDynamic', bound='num_of_x')
         ]),
         model.Struct('DyncompGreedy', [
-            model.StructMember('x', 'BuiltinDynamic', unlimited = True)
+            model.StructMember('x', 'BuiltinDynamic', unlimited=True)
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Unions():
     return process([
         model.Struct('Builtin', [
@@ -393,14 +415,15 @@ def Unions():
             model.UnionMember('c', 'Builtin', '3')
         ]),
         model.Struct('BuiltinOptional', [
-            model.StructMember('x', 'u32', optional = True)
+            model.StructMember('x', 'u32', optional=True)
         ]),
         model.Struct('FixcompOptional', [
-            model.StructMember('x', 'Builtin', optional = True)
+            model.StructMember('x', 'Builtin', optional=True)
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Enums():
     return process([
         model.Enum('Enum', [
@@ -409,18 +432,19 @@ def Enums():
         ]),
         model.Struct('DynEnum', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'Enum', bound = 'num_of_x')
+            model.StructMember('x', 'Enum', bound='num_of_x')
         ]),
         model.Constant('CONSTANT', '3'),
         model.Typedef('TU16', 'u16'),
         model.Struct('ConstantTypedefEnum', [
-            model.StructMember('a', 'u16', size = 'CONSTANT'),
+            model.StructMember('a', 'u16', size='CONSTANT'),
             model.StructMember('b', 'TU16'),
             model.StructMember('c', 'Enum')
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Floats():
     return process([
         model.Struct('Floats', [
@@ -429,26 +453,28 @@ def Floats():
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Bytes():
     return process([
         model.Struct('BytesFixed', [
-            model.StructMember('x', 'byte', size = 3)
+            model.StructMember('x', 'byte', size=3)
         ]),
         model.Struct('BytesDynamic', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'byte', bound = 'num_of_x')
+            model.StructMember('x', 'byte', bound='num_of_x')
         ]),
         model.Struct('BytesLimited', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'byte', size = 4, bound = 'num_of_x')
+            model.StructMember('x', 'byte', size=4, bound='num_of_x')
         ]),
         model.Struct('BytesGreedy', [
-            model.StructMember('x', 'byte', unlimited = True)
+            model.StructMember('x', 'byte', unlimited=True)
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Endpad():
     return process([
         model.Struct('Endpad', [
@@ -457,23 +483,24 @@ def Endpad():
         ]),
         model.Struct('EndpadFixed', [
             model.StructMember('x', 'u32'),
-            model.StructMember('y', 'u8', size = 3)
+            model.StructMember('y', 'u8', size=3)
         ]),
         model.Struct('EndpadDynamic', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', bound = 'num_of_x')
+            model.StructMember('x', 'u8', bound='num_of_x')
         ]),
         model.Struct('EndpadLimited', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', size = 2, bound = 'num_of_x')
+            model.StructMember('x', 'u8', size=2, bound='num_of_x')
         ]),
         model.Struct('EndpadGreedy', [
             model.StructMember('x', 'u32'),
-            model.StructMember('y', 'u8', unlimited = True)
+            model.StructMember('y', 'u8', unlimited=True)
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Scalarpad():
     return process([
         model.Struct('Scalarpad', [
@@ -496,15 +523,16 @@ def Scalarpad():
         ]),
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Unionpad():
     return process([
         model.Struct('UnionpadOptionalboolpad', [
             model.StructMember('x', 'u8'),
-            model.StructMember('y', 'u8', optional = True)
+            model.StructMember('y', 'u8', optional=True)
         ]),
         model.Struct('UnionpadOptionalvaluepad', [
-            model.StructMember('x', 'u64', optional = True)
+            model.StructMember('x', 'u64', optional=True)
         ]),
         model.Union('UnionpadDiscpad_Helper', [
             model.UnionMember('a', 'u8', '1')
@@ -523,21 +551,22 @@ def Unionpad():
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Arraypad():
     return process([
         model.Struct('ArraypadCounter', [
             model.StructMember('num_of_x', 'u8'),
-            model.StructMember('x', 'u16', bound = 'num_of_x')
+            model.StructMember('x', 'u16', bound='num_of_x')
         ]),
         model.Struct('ArraypadCounterSeparated', [
             model.StructMember('num_of_x', 'u8'),
             model.StructMember('y', 'u32'),
-            model.StructMember('x', 'u32', bound = 'num_of_x')
+            model.StructMember('x', 'u32', bound='num_of_x')
         ]),
         model.Struct('ArraypadCounterAligns_Helper', [
             model.StructMember('num_of_x', 'u16'),
-            model.StructMember('x', 'u8', bound = 'num_of_x')
+            model.StructMember('x', 'u8', bound='num_of_x')
         ]),
         model.Struct('ArraypadCounterAligns', [
             model.StructMember('x', 'u8'),
@@ -545,48 +574,49 @@ def Arraypad():
         ]),
         model.Struct('ArraypadFixed', [
             model.StructMember('x', 'u32'),
-            model.StructMember('y', 'u8', size = 3),
+            model.StructMember('y', 'u8', size=3),
             model.StructMember('z', 'u32')
         ]),
         model.Struct('ArraypadDynamic', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', bound = 'num_of_x'),
+            model.StructMember('x', 'u8', bound='num_of_x'),
             model.StructMember('y', 'u32')
         ]),
         model.Struct('ArraypadLimited', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', size = 2, bound = 'num_of_x'),
+            model.StructMember('x', 'u8', size=2, bound='num_of_x'),
             model.StructMember('y', 'u32')
         ])
     ])
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def Dynfields():
     return process([
         model.Struct('Dynfields', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', bound = 'num_of_x'),
+            model.StructMember('x', 'u8', bound='num_of_x'),
             model.StructMember('num_of_y', 'u16'),
-            model.StructMember('y', 'u16', bound = 'num_of_y'),
+            model.StructMember('y', 'u16', bound='num_of_y'),
             model.StructMember('z', 'u64')
         ]),
         model.Struct('DynfieldsMixed', [
             model.StructMember('num_of_x', 'u32'),
             model.StructMember('num_of_y', 'u16'),
-            model.StructMember('x', 'u8', bound = 'num_of_x'),
-            model.StructMember('y', 'u16', bound = 'num_of_y')
+            model.StructMember('x', 'u8', bound='num_of_x'),
+            model.StructMember('y', 'u16', bound='num_of_y')
         ]),
         model.Struct('DynfieldsOverlapped', [
             model.StructMember('num_of_a', 'u32'),
             model.StructMember('num_of_b', 'u32'),
-            model.StructMember('b', 'u16', bound = 'num_of_b'),
+            model.StructMember('b', 'u16', bound='num_of_b'),
             model.StructMember('num_of_c', 'u32'),
-            model.StructMember('c', 'u16', bound = 'num_of_c'),
-            model.StructMember('a', 'u16', bound = 'num_of_a')
+            model.StructMember('c', 'u16', bound='num_of_c'),
+            model.StructMember('a', 'u16', bound='num_of_a')
         ]),
         model.Struct('DynfieldsPartialpad_Helper', [
             model.StructMember('num_of_x', 'u8'),
-            model.StructMember('x', 'u8', bound = 'num_of_x'),
+            model.StructMember('x', 'u8', bound='num_of_x'),
             model.StructMember('y', 'u8'),
             model.StructMember('z', 'u64')
         ]),
@@ -596,7 +626,7 @@ def Dynfields():
         ]),
         model.Struct('DynfieldsScalarpartialpad_Helper', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', bound = 'num_of_x')
+            model.StructMember('x', 'u8', bound='num_of_x')
         ]),
         model.Struct('DynfieldsScalarpartialpad', [
             model.StructMember('x', 'DynfieldsScalarpartialpad_Helper'),
@@ -604,6 +634,7 @@ def Dynfields():
             model.StructMember('z', 'DynfieldsScalarpartialpad_Helper')
         ])
     ])
+
 
 def test_generate_builtin_encode(Builtin):
     assert generate_struct_encode(Builtin[0]) == """\
@@ -626,6 +657,7 @@ pos = pos + 8;
 pos = do_encode<E>(pos, x.x.data(), x.x.size());
 """
 
+
 def test_generate_fixcomp_encode(Fixcomp):
     assert generate_struct_encode(Fixcomp[1]) == """\
 pos = do_encode<E>(pos, x.x);
@@ -647,6 +679,7 @@ pos = pos + 16;
 pos = do_encode<E>(pos, x.x.data(), x.x.size());
 """
 
+
 def test_generate_dyncomp_encode(Dyncomp):
     assert generate_struct_encode(Dyncomp[1]) == """\
 pos = do_encode<E>(pos, x.x);
@@ -658,6 +691,7 @@ pos = do_encode<E>(pos, x.x.data(), uint32_t(x.x.size()));
     assert generate_struct_encode(Dyncomp[3]) == """\
 pos = do_encode<E>(pos, x.x.data(), x.x.size());
 """
+
 
 def test_generate_unions_encode(Unions):
     assert generate_union_encode(Unions[1]) == """\
@@ -677,6 +711,7 @@ pos = do_encode<E>(pos, x.x);
 pos = do_encode<E>(pos, x.x);
 """
 
+
 def test_generate_enums_encode(Enums):
     assert generate_struct_encode(Enums[1]) == """\
 pos = do_encode<E>(pos, uint32_t(x.x.size()));
@@ -688,12 +723,14 @@ pos = do_encode<E>(pos, x.b);
 pos = do_encode<E>(pos, x.c);
 """
 
+
 def test_generate_floats_encode(Floats):
     assert generate_struct_encode(Floats[0]) == """\
 pos = do_encode<E>(pos, x.a);
 pos = pos + 4;
 pos = do_encode<E>(pos, x.b);
 """
+
 
 def test_generate_bytes_encode(Bytes):
     assert generate_struct_encode(Bytes[0]) == """\
@@ -712,6 +749,7 @@ pos = pos + 4;
     assert generate_struct_encode(Bytes[3]) == """\
 pos = do_encode<E>(pos, x.x.data(), x.x.size());
 """
+
 
 def test_generate_endpad_encode(Endpad):
     assert generate_struct_encode(Endpad[0]) == """\
@@ -741,6 +779,7 @@ pos = do_encode<E>(pos, x.y.data(), x.y.size());
 pos = align<4>(pos);
 """
 
+
 def test_generate_scalarpad_encode(Scalarpad):
     assert generate_struct_encode(Scalarpad[0]) == """\
 pos = do_encode<E>(pos, x.x);
@@ -757,6 +796,7 @@ pos = do_encode<E>(pos, x.x);
 pos = pos + 1;
 pos = do_encode<E>(pos, x.y);
 """
+
 
 def test_generate_unionpad_encode(Unionpad):
     assert generate_struct_encode(Unionpad[0]) == """\
@@ -796,6 +836,7 @@ pos = do_encode<E>(pos, x.x);
 pos = pos + 7;
 pos = do_encode<E>(pos, x.y);
 """
+
 
 def test_generate_arraypad_encode(Arraypad):
     assert generate_struct_encode(Arraypad[0]) == """\
@@ -838,6 +879,7 @@ pos = pos + 2;
 pos = pos + 2;
 pos = do_encode<E>(pos, x.y);
 """
+
 
 def test_generate_dynfields_encode(Dynfields):
     assert generate_struct_encode(Dynfields[0]) == """\
@@ -891,6 +933,7 @@ pos = do_encode<E>(pos, x.y);
 pos = do_encode<E>(pos, x.z);
 """
 
+
 def test_generate_builtin_decode(Builtin):
     assert generate_struct_decode(Builtin[0]) == """\
 do_decode<E>(x.x, pos, end) &&
@@ -911,6 +954,7 @@ do_decode_advance(8, pos, end)
     assert generate_struct_decode(Builtin[4]) == """\
 do_decode_greedy<E>(x.x, pos, end)
 """
+
 
 def test_generate_fixcomp_decode(Fixcomp):
     assert generate_struct_decode(Fixcomp[1]) == """\
@@ -933,6 +977,7 @@ do_decode_advance(16, pos, end)
 do_decode_greedy<E>(x.x, pos, end)
 """
 
+
 def test_generate_dyncomp_decode(Dyncomp):
     assert generate_struct_decode(Dyncomp[1]) == """\
 do_decode<E>(x.x, pos, end)
@@ -944,6 +989,7 @@ do_decode<E>(x.x.data(), x.x.size(), pos, end)
     assert generate_struct_decode(Dyncomp[3]) == """\
 do_decode_greedy<E>(x.x, pos, end)
 """
+
 
 def test_generate_unions_decode(Unions):
     assert generate_union_decode(Unions[1]) == """\
@@ -964,6 +1010,7 @@ do_decode<E>(x.x, pos, end)
 do_decode<E>(x.x, pos, end)
 """
 
+
 def test_generate_enums_decode(Enums):
     assert generate_struct_decode(Enums[1]) == """\
 do_decode_resize<E, uint32_t>(x.x, pos, end) &&
@@ -975,12 +1022,14 @@ do_decode<E>(x.b, pos, end) &&
 do_decode<E>(x.c, pos, end)
 """
 
+
 def test_generate_floats_decode(Floats):
     assert generate_struct_decode(Floats[0]) == """\
 do_decode<E>(x.a, pos, end) &&
 do_decode_advance(4, pos, end) &&
 do_decode<E>(x.b, pos, end)
 """
+
 
 def test_generate_bytes_decode(Bytes):
     assert generate_struct_decode(Bytes[0]) == """\
@@ -999,6 +1048,7 @@ do_decode_advance(4, pos, end)
     assert generate_struct_decode(Bytes[3]) == """\
 do_decode_greedy<E>(x.x, pos, end)
 """
+
 
 def test_generate_endpad_decode(Endpad):
     assert generate_struct_decode(Endpad[0]) == """\
@@ -1028,6 +1078,7 @@ do_decode_greedy<E>(x.y, pos, end) &&
 do_decode_align<4>(pos, end)
 """
 
+
 def test_generate_scalarpad_decode(Scalarpad):
     assert generate_struct_decode(Scalarpad[0]) == """\
 do_decode<E>(x.x, pos, end) &&
@@ -1044,6 +1095,7 @@ do_decode<E>(x.x, pos, end) &&
 do_decode_advance(1, pos, end) &&
 do_decode<E>(x.y, pos, end)
 """
+
 
 def test_generate_unionpad_decode(Unionpad):
     assert generate_struct_decode(Unionpad[0]) == """\
@@ -1086,6 +1138,7 @@ do_decode_advance(7, pos, end) &&
 do_decode<E>(x.y, pos, end)
 """
 
+
 def test_generate_arraypad_decode(Arraypad):
     assert generate_struct_decode(Arraypad[0]) == """\
 do_decode_resize<E, uint8_t>(x.x, pos, end) &&
@@ -1127,6 +1180,7 @@ do_decode_advance(2, pos, end) &&
 do_decode_advance(2, pos, end) &&
 do_decode<E>(x.y, pos, end)
 """
+
 
 def test_generate_dynfields_decode(Dynfields):
     assert generate_struct_decode(Dynfields[0]) == """\
@@ -1180,6 +1234,7 @@ do_decode<E>(x.y, pos, end) &&
 do_decode<E>(x.z, pos, end)
 """
 
+
 def test_generate_builtin_print(Builtin):
     assert generate_struct_print(Builtin[0]) == """\
 do_print(out, indent, "x", x.x);
@@ -1197,6 +1252,7 @@ do_print(out, indent, "x", x.x.data(), std::min(x.x.size(), size_t(2)));
     assert generate_struct_print(Builtin[4]) == """\
 do_print(out, indent, "x", x.x.data(), x.x.size());
 """
+
 
 def test_generate_fixcomp_print(Fixcomp):
     assert generate_struct_print(Fixcomp[1]) == """\
@@ -1216,6 +1272,7 @@ do_print(out, indent, "x", x.x.data(), std::min(x.x.size(), size_t(2)));
 do_print(out, indent, "x", x.x.data(), x.x.size());
 """
 
+
 def test_generate_dyncomp_print(Dyncomp):
     assert generate_struct_print(Dyncomp[1]) == """\
 do_print(out, indent, "x", x.x);
@@ -1226,6 +1283,7 @@ do_print(out, indent, "x", x.x.data(), x.x.size());
     assert generate_struct_print(Dyncomp[3]) == """\
 do_print(out, indent, "x", x.x.data(), x.x.size());
 """
+
 
 def test_generate_unions_print(Unions):
     assert generate_union_print(Unions[1]) == """\
@@ -1243,6 +1301,7 @@ if (x.x) do_print(out, indent, "x", *x.x);
 if (x.x) do_print(out, indent, "x", *x.x);
 """
 
+
 def test_generate_enums_print(Enums):
     assert generate_struct_print(Enums[1]) == """\
 do_print(out, indent, "x", x.x.data(), x.x.size());
@@ -1253,11 +1312,13 @@ do_print(out, indent, "b", x.b);
 do_print(out, indent, "c", x.c);
 """
 
+
 def test_generate_floats_print(Floats):
     assert generate_struct_print(Floats[0]) == """\
 do_print(out, indent, "a", x.a);
 do_print(out, indent, "b", x.b);
 """
+
 
 def test_generate_bytes_print(Bytes):
     assert generate_struct_print(Bytes[0]) == """\
@@ -1272,6 +1333,7 @@ do_print(out, indent, "x", std::make_pair(x.x.data(), std::min(x.x.size(), size_
     assert generate_struct_print(Bytes[3]) == """\
 do_print(out, indent, "x", std::make_pair(x.x.data(), x.x.size()));
 """
+
 
 def test_generate_endpad_print(Endpad):
     assert generate_struct_print(Endpad[0]) == """\
@@ -1293,6 +1355,7 @@ do_print(out, indent, "x", x.x);
 do_print(out, indent, "y", x.y.data(), x.y.size());
 """
 
+
 def test_generate_scalarpad_print(Scalarpad):
     assert generate_struct_print(Scalarpad[0]) == """\
 do_print(out, indent, "x", x.x);
@@ -1306,6 +1369,7 @@ do_print(out, indent, "y", x.y);
 do_print(out, indent, "x", x.x);
 do_print(out, indent, "y", x.y);
 """
+
 
 def test_generate_unionpad_print(Unionpad):
     assert generate_struct_print(Unionpad[0]) == """\
@@ -1337,6 +1401,7 @@ do_print(out, indent, "x", x.x);
 do_print(out, indent, "y", x.y);
 """
 
+
 def test_generate_arraypad_print(Arraypad):
     assert generate_struct_print(Arraypad[0]) == """\
 do_print(out, indent, "x", x.x.data(), x.x.size());
@@ -1365,6 +1430,7 @@ do_print(out, indent, "y", x.y);
 do_print(out, indent, "x", x.x.data(), std::min(x.x.size(), size_t(2)));
 do_print(out, indent, "y", x.y);
 """
+
 
 def test_generate_dynfields_print(Dynfields):
     assert generate_struct_print(Dynfields[0]) == """\
@@ -1399,12 +1465,14 @@ do_print(out, indent, "y", x.y);
 do_print(out, indent, "z", x.z);
 """
 
+
 def test_generate_builtin_encoded_byte_size(Builtin):
     assert generate_struct_encoded_byte_size(Builtin[0]) == '8'
     assert generate_struct_encoded_byte_size(Builtin[1]) == '8'
     assert generate_struct_encoded_byte_size(Builtin[2]) == '-1'
     assert generate_struct_encoded_byte_size(Builtin[3]) == '12'
     assert generate_struct_encoded_byte_size(Builtin[4]) == '-1'
+
 
 def test_generate_fixcomp_encoded_byte_size(Fixcomp):
     assert generate_struct_encoded_byte_size(Fixcomp[1]) == '16'
@@ -1413,28 +1481,34 @@ def test_generate_fixcomp_encoded_byte_size(Fixcomp):
     assert generate_struct_encoded_byte_size(Fixcomp[4]) == '20'
     assert generate_struct_encoded_byte_size(Fixcomp[5]) == '-1'
 
+
 def test_generate_dyncomp_encoded_byte_size(Dyncomp):
     assert generate_struct_encoded_byte_size(Dyncomp[1]) == '-1'
     assert generate_struct_encoded_byte_size(Dyncomp[2]) == '-1'
     assert generate_struct_encoded_byte_size(Dyncomp[3]) == '-1'
+
 
 def test_generate_unions_encoded_byte_size(Unions):
     assert generate_union_encoded_byte_size(Unions[1]) == '12'
     assert generate_struct_encoded_byte_size(Unions[2]) == '8'
     assert generate_struct_encoded_byte_size(Unions[3]) == '12'
 
+
 def test_generate_enums_encoded_byte_size(Enums):
     assert generate_struct_encoded_byte_size(Enums[1]) == '-1'
     assert generate_struct_encoded_byte_size(Enums[4]) == '12'
 
+
 def test_generate_floats_encoded_byte_size(Floats):
     assert generate_struct_encoded_byte_size(Floats[0]) == '16'
+
 
 def test_generate_bytes_encoded_byte_size(Bytes):
     assert generate_struct_encoded_byte_size(Bytes[0]) == '3'
     assert generate_struct_encoded_byte_size(Bytes[1]) == '-1'
     assert generate_struct_encoded_byte_size(Bytes[2]) == '8'
     assert generate_struct_encoded_byte_size(Bytes[3]) == '-1'
+
 
 def test_generate_endpad_encoded_byte_size(Endpad):
     assert generate_struct_encoded_byte_size(Endpad[0]) == '4'
@@ -1443,10 +1517,12 @@ def test_generate_endpad_encoded_byte_size(Endpad):
     assert generate_struct_encoded_byte_size(Endpad[3]) == '8'
     assert generate_struct_encoded_byte_size(Endpad[4]) == '-1'
 
+
 def test_generate_scalarpad_encoded_byte_size(Scalarpad):
     assert generate_struct_encoded_byte_size(Scalarpad[0]) == '4'
     assert generate_struct_encoded_byte_size(Scalarpad[2]) == '4'
     assert generate_struct_encoded_byte_size(Scalarpad[4]) == '4'
+
 
 def test_generate_unionpad_encoded_byte_size(Unionpad):
     assert generate_struct_encoded_byte_size(Unionpad[0]) == '12'
@@ -1455,6 +1531,7 @@ def test_generate_unionpad_encoded_byte_size(Unionpad):
     assert generate_struct_encoded_byte_size(Unionpad[3]) == '12'
     assert generate_union_encoded_byte_size(Unionpad[4]) == '16'
     assert generate_struct_encoded_byte_size(Unionpad[5]) == '24'
+
 
 def test_generate_arraypad_encoded_byte_size(Arraypad):
     assert generate_struct_encoded_byte_size(Arraypad[0]) == '-1'
@@ -1465,6 +1542,7 @@ def test_generate_arraypad_encoded_byte_size(Arraypad):
     assert generate_struct_encoded_byte_size(Arraypad[5]) == '-1'
     assert generate_struct_encoded_byte_size(Arraypad[6]) == '12'
 
+
 def test_generate_dynfields_encoded_byte_size(Dynfields):
     assert generate_struct_encoded_byte_size(Dynfields[0]) == '-1'
     assert generate_struct_encoded_byte_size(Dynfields[1]) == '-1'
@@ -1473,6 +1551,7 @@ def test_generate_dynfields_encoded_byte_size(Dynfields):
     assert generate_struct_encoded_byte_size(Dynfields[4]) == '-1'
     assert generate_struct_encoded_byte_size(Dynfields[5]) == '-1'
     assert generate_struct_encoded_byte_size(Dynfields[6]) == '-1'
+
 
 def test_generate_builtin_get_byte_size(Builtin):
     assert generate_struct_get_byte_size(Builtin[0]) == """\
@@ -1491,6 +1570,7 @@ return 12;
 return x.size() * 4;
 """
 
+
 def test_generate_fixcomp_get_byte_size(Fixcomp):
     assert generate_struct_get_byte_size(Fixcomp[1]) == """\
 return 16;
@@ -1508,6 +1588,7 @@ return 20;
 return x.size() * 8;
 """
 
+
 def test_generate_dyncomp_get_byte_size(Dyncomp):
     assert generate_struct_get_byte_size(Dyncomp[1]) == """\
 return x.get_byte_size();
@@ -1518,6 +1599,7 @@ return std::accumulate(x.begin(), x.end(), size_t(), prophy::detail::byte_size()
     assert generate_struct_get_byte_size(Dyncomp[3]) == """\
 return std::accumulate(x.begin(), x.end(), size_t(), prophy::detail::byte_size());
 """
+
 
 def test_generate_unions_get_byte_size(Unions):
     assert generate_union_get_byte_size(Unions[1]) == """\
@@ -1530,6 +1612,7 @@ return 8;
 return 12;
 """
 
+
 def test_generate_enums_get_byte_size(Enums):
     assert generate_struct_get_byte_size(Enums[1]) == """\
 return x.size() * 4 + 4;
@@ -1538,10 +1621,12 @@ return x.size() * 4 + 4;
 return 12;
 """
 
+
 def test_generate_floats_get_byte_size(Floats):
     assert generate_struct_get_byte_size(Floats[0]) == """\
 return 16;
 """
+
 
 def test_generate_bytes_get_byte_size(Bytes):
     assert generate_struct_get_byte_size(Bytes[0]) == """\
@@ -1558,6 +1643,7 @@ return 8;
     assert generate_struct_get_byte_size(Bytes[3]) == """\
 return x.size() * 1;
 """
+
 
 def test_generate_endpad_get_byte_size(Endpad):
     assert generate_struct_get_byte_size(Endpad[0]) == """\
@@ -1580,6 +1666,7 @@ return prophy::detail::nearest<4>(
 );
 """
 
+
 def test_generate_scalarpad_get_byte_size(Scalarpad):
     assert generate_struct_get_byte_size(Scalarpad[0]) == """\
 return 4;
@@ -1590,6 +1677,7 @@ return 4;
     assert generate_struct_get_byte_size(Scalarpad[4]) == """\
 return 4;
 """
+
 
 def test_generate_unionpad_get_byte_size(Unionpad):
     assert generate_struct_get_byte_size(Unionpad[0]) == """\
@@ -1610,6 +1698,7 @@ return 16;
     assert generate_struct_get_byte_size(Unionpad[5]) == """\
 return 24;
 """
+
 
 def test_generate_arraypad_get_byte_size(Arraypad):
     assert generate_struct_get_byte_size(Arraypad[0]) == """\
@@ -1637,6 +1726,7 @@ return prophy::detail::nearest<4>(
     assert generate_struct_get_byte_size(Arraypad[6]) == """\
 return 12;
 """
+
 
 def test_generate_dynfields_get_byte_size(Dynfields):
     assert generate_struct_get_byte_size(Dynfields[0]) == """\
@@ -1677,6 +1767,7 @@ return prophy::detail::nearest<4>(
 return x.get_byte_size() + y.get_byte_size() + z.get_byte_size();
 """
 
+
 def test_generate_builtin_fields(Builtin):
     assert generate_struct_fields(Builtin[0]) == """\
 uint32_t x;
@@ -1694,6 +1785,7 @@ std::vector<uint32_t> x; /// limit 2
     assert generate_struct_fields(Builtin[4]) == """\
 std::vector<uint32_t> x; /// greedy
 """
+
 
 def test_generate_fixcomp_fields(Fixcomp):
     assert generate_struct_fields(Fixcomp[1]) == """\
@@ -1713,6 +1805,7 @@ std::vector<Builtin> x; /// limit 2
 std::vector<Builtin> x; /// greedy
 """
 
+
 def test_generate_dyncomp_fields(Dyncomp):
     assert generate_struct_fields(Dyncomp[1]) == """\
 BuiltinDynamic x;
@@ -1723,6 +1816,7 @@ std::vector<BuiltinDynamic> x;
     assert generate_struct_fields(Dyncomp[3]) == """\
 std::vector<BuiltinDynamic> x; /// greedy
 """
+
 
 def test_generate_unions_fields(Unions):
     assert generate_union_fields(Unions[1]) == """\
@@ -1748,6 +1842,7 @@ optional<uint32_t> x;
 optional<Builtin> x;
 """
 
+
 def test_generate_enums_fields(Enums):
     assert generate_struct_fields(Enums[1]) == """\
 std::vector<Enum> x;
@@ -1758,11 +1853,13 @@ TU16 b;
 Enum c;
 """
 
+
 def test_generate_floats_fields(Floats):
     assert generate_struct_fields(Floats[0]) == """\
 float a;
 double b;
 """
+
 
 def test_generate_bytes_fields(Bytes):
     assert generate_struct_fields(Bytes[0]) == """\
@@ -1777,6 +1874,7 @@ std::vector<uint8_t> x; /// limit 4
     assert generate_struct_fields(Bytes[3]) == """\
 std::vector<uint8_t> x; /// greedy
 """
+
 
 def test_generate_endpad_fields(Endpad):
     assert generate_struct_fields(Endpad[0]) == """\
@@ -1798,6 +1896,7 @@ uint32_t x;
 std::vector<uint8_t> y; /// greedy
 """
 
+
 def test_generate_scalarpad_fields(Scalarpad):
     assert generate_struct_fields(Scalarpad[0]) == """\
 uint8_t x;
@@ -1811,6 +1910,7 @@ uint16_t y;
 uint8_t x;
 ScalarpadComppost_Helper y;
 """
+
 
 def test_generate_unionpad_fields(Unionpad):
     assert generate_struct_fields(Unionpad[0]) == """\
@@ -1852,6 +1952,7 @@ uint8_t x;
 UnionpadArmpad_Helper y;
 """
 
+
 def test_generate_arraypad_fields(Arraypad):
     assert generate_struct_fields(Arraypad[0]) == """\
 std::vector<uint16_t> x;
@@ -1880,6 +1981,7 @@ uint32_t y;
 std::vector<uint8_t> x; /// limit 2
 uint32_t y;
 """
+
 
 def test_generate_dynfields_fields(Dynfields):
     assert generate_struct_fields(Dynfields[0]) == """\
@@ -1914,6 +2016,7 @@ DynfieldsScalarpartialpad_Helper y;
 DynfieldsScalarpartialpad_Helper z;
 """
 
+
 def test_generate_builtin_constructor(Builtin):
     assert generate_struct_constructor(Builtin[0]) == """\
 Builtin(): x(), y() { }
@@ -1935,6 +2038,7 @@ BuiltinLimited(const std::vector<uint32_t>& _1): x(_1) { }
 BuiltinGreedy() { }
 BuiltinGreedy(const std::vector<uint32_t>& _1): x(_1) { }
 """
+
 
 def test_generate_fixcomp_constructor(Fixcomp):
     assert generate_struct_constructor(Fixcomp[1]) == """\
@@ -1958,6 +2062,7 @@ FixcompGreedy() { }
 FixcompGreedy(const std::vector<Builtin>& _1): x(_1) { }
 """
 
+
 def test_generate_dyncomp_constructor(Dyncomp):
     assert generate_struct_constructor(Dyncomp[1]) == """\
 Dyncomp() { }
@@ -1971,6 +2076,7 @@ DyncompDynamic(const std::vector<BuiltinDynamic>& _1): x(_1) { }
 DyncompGreedy() { }
 DyncompGreedy(const std::vector<BuiltinDynamic>& _1): x(_1) { }
 """
+
 
 def test_generate_unions_constructor(Unions):
     assert generate_union_constructor(Unions[1]) == """\
@@ -1988,6 +2094,7 @@ FixcompOptional() { }
 FixcompOptional(const optional<Builtin>& _1): x(_1) { }
 """
 
+
 def test_generate_enums_constructor(Enums):
     assert generate_struct_constructor(Enums[1]) == """\
 DynEnum() { }
@@ -1998,11 +2105,13 @@ ConstantTypedefEnum(): a(), b(), c(Enum_One) { }
 ConstantTypedefEnum(const array<uint16_t, CONSTANT>& _1, TU16 _2, Enum _3): a(_1), b(_2), c(_3) { }
 """
 
+
 def test_generate_floats_constructor(Floats):
     assert generate_struct_constructor(Floats[0]) == """\
 Floats(): a(), b() { }
 Floats(float _1, double _2): a(_1), b(_2) { }
 """
+
 
 def test_generate_bytes_constructor(Bytes):
     assert generate_struct_constructor(Bytes[0]) == """\
@@ -2021,6 +2130,7 @@ BytesLimited(const std::vector<uint8_t>& _1): x(_1) { }
 BytesGreedy() { }
 BytesGreedy(const std::vector<uint8_t>& _1): x(_1) { }
 """
+
 
 def test_generate_endpad_constructor(Endpad):
     assert generate_struct_constructor(Endpad[0]) == """\
@@ -2044,6 +2154,7 @@ EndpadGreedy(): x() { }
 EndpadGreedy(uint32_t _1, const std::vector<uint8_t>& _2): x(_1), y(_2) { }
 """
 
+
 def test_generate_scalarpad_constructor(Scalarpad):
     assert generate_struct_constructor(Scalarpad[0]) == """\
 Scalarpad(): x(), y() { }
@@ -2057,6 +2168,7 @@ ScalarpadComppre(const ScalarpadComppre_Helper& _1, uint16_t _2): x(_1), y(_2) {
 ScalarpadComppost(): x() { }
 ScalarpadComppost(uint8_t _1, const ScalarpadComppost_Helper& _2): x(_1), y(_2) { }
 """
+
 
 def test_generate_unionpad_constructor(Unionpad):
     assert generate_struct_constructor(Unionpad[0]) == """\
@@ -2084,6 +2196,7 @@ UnionpadArmpad_Helper(prophy::detail::int2type<discriminator_b>, uint64_t _1): d
 UnionpadArmpad(): x() { }
 UnionpadArmpad(uint8_t _1, const UnionpadArmpad_Helper& _2): x(_1), y(_2) { }
 """
+
 
 def test_generate_arraypad_constructor(Arraypad):
     assert generate_struct_constructor(Arraypad[0]) == """\
@@ -2115,6 +2228,7 @@ ArraypadLimited(): y() { }
 ArraypadLimited(const std::vector<uint8_t>& _1, uint32_t _2): x(_1), y(_2) { }
 """
 
+
 def test_generate_dynfields_constructor(Dynfields):
     assert generate_struct_constructor(Dynfields[0]) == """\
 Dynfields(): z() { }
@@ -2145,6 +2259,7 @@ DynfieldsScalarpartialpad() { }
 DynfieldsScalarpartialpad(const DynfieldsScalarpartialpad_Helper& _1, const DynfieldsScalarpartialpad_Helper& _2, const DynfieldsScalarpartialpad_Helper& _3): x(_1), y(_2), z(_3) { }
 """
 
+
 def test_initializer_list_typedefed_enum():
     nodes = process([
         model.Enum('Enum', [
@@ -2166,6 +2281,7 @@ Struct(TEnum _1): x(_1) { }
 Union(): discriminator(discriminator_x), x(Enum_One) { }
 Union(prophy::detail::int2type<discriminator_x>, TEnum _1): discriminator(discriminator_x), x(_1) { }
 """
+
 
 def test_generate_hpp_newlines():
     nodes = process([
@@ -2241,6 +2357,7 @@ struct B : public prophy::detail::message<B>
 };
 """
 
+
 def test_generate_hpp(Union):
     assert generate_hpp(Union, 'MyFile') == """\
 #ifndef _PROPHY_GENERATED_FULL_MyFile_HPP
@@ -2289,6 +2406,7 @@ struct X : public prophy::detail::message<X>
 
 #endif  /* _PROPHY_GENERATED_FULL_MyFile_HPP */
 """
+
 
 def test_generate_cpp(Struct):
     assert generate_cpp(Struct, 'MyFile') == """\
@@ -2375,6 +2493,7 @@ template void message_impl<Y>::print(const Y& x, std::ostream& out, size_t inden
 } // namespace prophy
 """
 
+
 def test_generate_hpp_with_included_struct():
     nodes = process([
         model.Include('Input', process([
@@ -2414,6 +2533,7 @@ struct Y : public prophy::detail::message<Y>
 } // namespace prophy
 """ in generate_hpp(nodes, 'MyFile')
 
+
 def test_exception_when_byte_size_is_unknown(tmpdir_cwd):
     nodes = process([
         model.Struct('X', [
@@ -2424,15 +2544,17 @@ def test_exception_when_byte_size_is_unknown(tmpdir_cwd):
         CppFullGenerator('.').serialize(nodes, 'Filename')
     assert "X byte size unknown" == str(e.value)
 
+
 def test_exception_when_numeric_size_is_unknown(tmpdir_cwd):
     nodes = process([
         model.Struct('X', [
-            model.StructMember('x', 'u32', size = 'Unknown')
+            model.StructMember('x', 'u32', size='Unknown')
         ])
     ])
     with pytest.raises(GenerateError) as e:
         CppFullGenerator('.').serialize(nodes, 'Filename')
     assert "X byte size unknown" == str(e.value)
+
 
 def test_exception_when_union_byte_size_is_unknown(tmpdir_cwd):
     nodes = process([
@@ -2444,34 +2566,37 @@ def test_exception_when_union_byte_size_is_unknown(tmpdir_cwd):
         CppFullGenerator('.').serialize(nodes, 'Filename')
     assert "X byte size unknown" == str(e.value)
 
+
 def test_exception_when_multiple_arrays_are_bounded_by_the_same_member(tmpdir_cwd):
     nodes = process([
         model.Struct('X', [
             model.StructMember('num_of_elements', 'u32'),
-            model.StructMember('array1', 'u32', bound = 'num_of_elements'),
-            model.StructMember('array2', 'u32', bound = 'num_of_elements'),
+            model.StructMember('array1', 'u32', bound='num_of_elements'),
+            model.StructMember('array2', 'u32', bound='num_of_elements'),
         ])
     ])
     with pytest.raises(GenerateError) as e:
         CppFullGenerator('.').serialize(nodes, 'Filename')
     assert "Multiple arrays bounded by the same member (num_of_elements) in struct X is unsupported" == str(e.value)
 
+
 def test_get_byte_size_when_array_delimiter_is_a_typedef():
     nodes = process([
         model.Typedef('IntType', 'u32'),
         model.Struct('X', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'IntType', bound = 'num_of_x')
+            model.StructMember('x', 'IntType', bound='num_of_x')
         ])
     ])
     assert 'x.size() * 4 + 4' in generate_struct_get_byte_size(nodes[1])
+
 
 def test_encode_and_decode_when_array_delimiter_is_a_typedef():
     nodes = process([
         model.Typedef('IntType', 'u32'),
         model.Struct('X', [
             model.StructMember('num_of_x', 'IntType'),
-            model.StructMember('x', 'u32', bound = 'num_of_x')
+            model.StructMember('x', 'u32', bound='num_of_x')
         ])
     ])
     assert 'uint32_t(x.x.size())' in generate_struct_encode(nodes[1])

--- a/prophyc/tests/generators/test_python.py
+++ b/prophyc/tests/generators/test_python.py
@@ -48,9 +48,11 @@ def test_enums_rendering():
 
     ref = """\
 class EEnum(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
-    _enumerators  = [('EEnum_A', 0),
-                     ('EEnum_B', 1),
-                     ('EEnum_C', 2)]
+    _enumerators = [
+        ('EEnum_A', 0),
+        ('EEnum_B', 1),
+        ('EEnum_C', 2)
+    ]
 
 EEnum_A = 0
 EEnum_B = 1
@@ -67,10 +69,12 @@ def test_struct_rendering():
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('a', prophy.u8),
-                   ('b', prophy.i64),
-                   ('c', prophy.r32),
-                   ('d', TTypeX)]
+    _descriptor = [
+        ('a', prophy.u8),
+        ('b', prophy.i64),
+        ('c', prophy.r32),
+        ('d', TTypeX)
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -81,8 +85,10 @@ def test_struct_rendering_with_dynamic_array():
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('tmpName', TNumberOfItems),
-                   ('a', prophy.array(prophy.u8, bound = 'tmpName'))]
+    _descriptor = [
+        ('tmpName', TNumberOfItems),
+        ('a', prophy.array(prophy.u8, bound = 'tmpName'))
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -95,10 +101,12 @@ def test_struct_rendering_with_dynamic_arrays_bounded_by_the_same_member():
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('numOfElements', TNumberOfItems),
-                   ('tmpName', prophy.u32),
-                   ('a', prophy.array(prophy.u8, bound = 'numOfElements')),
-                   ('b', prophy.array(prophy.r32, bound = 'numOfElements'))]
+    _descriptor = [
+        ('numOfElements', TNumberOfItems),
+        ('tmpName', prophy.u32),
+        ('a', prophy.array(prophy.u8, bound = 'numOfElements')),
+        ('b', prophy.array(prophy.r32, bound = 'numOfElements'))
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -108,7 +116,9 @@ def test_struct_rendering_with_static_array():
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('a', prophy.array(prophy.u8, size = NUM_OF_ARRAY_ELEMS))]
+    _descriptor = [
+        ('a', prophy.array(prophy.u8, size = NUM_OF_ARRAY_ELEMS))
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -119,8 +129,10 @@ def test_struct_rendering_with_limited_array():
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('a_len', prophy.u8),
-                   ('a', prophy.array(prophy.u8, bound = 'a_len', size = NUM_OF_ARRAY_ELEMS))]
+    _descriptor = [
+        ('a_len', prophy.u8),
+        ('a', prophy.array(prophy.u8, bound = 'a_len', size = NUM_OF_ARRAY_ELEMS))
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -130,7 +142,9 @@ def test_struct_rendering_with_optional():
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('a', prophy.optional(prophy.u32))]
+    _descriptor = [
+        ('a', prophy.optional(prophy.u32))
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -140,7 +154,9 @@ def test_struct_rendering_with_byte():
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('a', prophy.u8)]
+    _descriptor = [
+        ('a', prophy.u8)
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -150,7 +166,9 @@ def test_struct_rendering_with_byte_array():
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('a', prophy.bytes())]
+    _descriptor = [
+        ('a', prophy.bytes())
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -162,9 +180,11 @@ def test_union_rendering():
 
     ref = """\
 class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
-    _descriptor = [('a', A, 0),
-                   ('b', B, 1),
-                   ('c', C, 2)]
+    _descriptor = [
+        ('a', A, 0),
+        ('b', B, 1),
+        ('c', C, 2)
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -176,9 +196,11 @@ def test_union_rendering_2():
 
     ref = """\
 class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
-    _descriptor = [('a', prophy.i8, 0),
-                   ('b', prophy.u32, 1),
-                   ('c', prophy.r64, 2)]
+    _descriptor = [
+        ('a', prophy.i8, 0),
+        ('b', prophy.u32, 1),
+        ('c', prophy.r64, 2)
+    ]
 """
     assert ref == serialize(nodes)
 
@@ -232,10 +254,12 @@ td_elem_name_140 = i_td_elem_val_140
 td_elem_name_140 = u_td_elem_val_140
 
 class test(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
-    _enumerators  = [('elem_1', val_1),
-                     ('elem_31', val_31),
-                     ('elem_61', val_61),
-                     ('elem_91', val_91)]
+    _enumerators = [
+        ('elem_1', val_1),
+        ('elem_31', val_31),
+        ('elem_61', val_61),
+        ('elem_91', val_91)
+    ]
 
 elem_1 = val_1
 elem_31 = val_31
@@ -243,6 +267,8 @@ elem_61 = val_61
 elem_91 = val_91
 
 class MAC_L2CallConfigResp(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('messageResult', SMessageResult)]
+    _descriptor = [
+        ('messageResult', SMessageResult)
+    ]
 """
     assert ref == output

--- a/prophyc/tests/generators/test_python.py
+++ b/prophyc/tests/generators/test_python.py
@@ -1,8 +1,10 @@
 from prophyc import model
 from prophyc.generators.python import PythonGenerator
 
+
 def serialize(nodes):
     return PythonGenerator().generate_definitions(nodes)
+
 
 def test_includes_rendering():
     nodes = [
@@ -18,6 +20,7 @@ from nowiejsze_powidlo import *
 """
     assert ref == serialize(nodes)
 
+
 def test_constants_rendering():
     nodes = [model.Constant("CONST_A", "0"),
              model.Constant("CONST_B", "31")]
@@ -28,6 +31,7 @@ CONST_B = 31
 """
     assert ref == serialize(nodes)
 
+
 def test_typedefs_rendering():
     nodes = [model.Typedef("a", "b")]
 
@@ -35,6 +39,7 @@ def test_typedefs_rendering():
 a = b
 """
     assert ref == serialize(nodes)
+
 
 def test_enums_rendering():
     nodes = [model.Enum("EEnum", [(model.EnumMember("EEnum_A", "0")),
@@ -53,6 +58,7 @@ EEnum_C = 2
 """
     assert ref == serialize(nodes)
 
+
 def test_struct_rendering():
     nodes = [model.Struct("Struct", [(model.StructMember("a", "u8")),
                                      (model.StructMember("b", "i64")),
@@ -68,9 +74,10 @@ class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
 """
     assert ref == serialize(nodes)
 
+
 def test_struct_rendering_with_dynamic_array():
     nodes = [model.Struct("Struct", [model.StructMember("tmpName", "TNumberOfItems"),
-                                     model.StructMember("a", "u8", bound = "tmpName")])]
+                                     model.StructMember("a", "u8", bound="tmpName")])]
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
@@ -79,11 +86,12 @@ class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
 """
     assert ref == serialize(nodes)
 
+
 def test_struct_rendering_with_dynamic_arrays_bounded_by_the_same_member():
     nodes = [model.Struct("Struct", [model.StructMember("numOfElements", "TNumberOfItems"),
                                      model.StructMember("tmpName", "u32"),
-                                     model.StructMember("a", "u8", bound = "numOfElements"),
-                                     model.StructMember("b", "r32", bound = "numOfElements")])]
+                                     model.StructMember("a", "u8", bound="numOfElements"),
+                                     model.StructMember("b", "r32", bound="numOfElements")])]
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
@@ -94,8 +102,9 @@ class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
 """
     assert ref == serialize(nodes)
 
+
 def test_struct_rendering_with_static_array():
-    nodes = [model.Struct("Struct", [model.StructMember("a", "u8", size = "NUM_OF_ARRAY_ELEMS")])]
+    nodes = [model.Struct("Struct", [model.StructMember("a", "u8", size="NUM_OF_ARRAY_ELEMS")])]
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
@@ -103,9 +112,10 @@ class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
 """
     assert ref == serialize(nodes)
 
+
 def test_struct_rendering_with_limited_array():
     nodes = [model.Struct("Struct", [model.StructMember("a_len", "u8"),
-                                     model.StructMember("a", "u8", bound = "a_len", size = "NUM_OF_ARRAY_ELEMS")])]
+                                     model.StructMember("a", "u8", bound="a_len", size="NUM_OF_ARRAY_ELEMS")])]
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
@@ -114,14 +124,16 @@ class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
 """
     assert ref == serialize(nodes)
 
+
 def test_struct_rendering_with_optional():
-    nodes = [model.Struct("Struct", [model.StructMember("a", "u32", optional = True)])]
+    nodes = [model.Struct("Struct", [model.StructMember("a", "u32", optional=True)])]
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
     _descriptor = [('a', prophy.optional(prophy.u32))]
 """
     assert ref == serialize(nodes)
+
 
 def test_struct_rendering_with_byte():
     nodes = [model.Struct("Struct", [model.StructMember("a", "byte")])]
@@ -132,14 +144,16 @@ class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
 """
     assert ref == serialize(nodes)
 
+
 def test_struct_rendering_with_byte_array():
-    nodes = [model.Struct("Struct", [model.StructMember("a", "byte", unlimited = True)])]
+    nodes = [model.Struct("Struct", [model.StructMember("a", "byte", unlimited=True)])]
 
     ref = """\
 class Struct(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
     _descriptor = [('a', prophy.bytes())]
 """
     assert ref == serialize(nodes)
+
 
 def test_union_rendering():
     nodes = [model.Union("U", [model.UnionMember("a", "A", "0"),
@@ -154,6 +168,7 @@ class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
 """
     assert ref == serialize(nodes)
 
+
 def test_union_rendering_2():
     nodes = [model.Union("U", [model.UnionMember("a", "i8", "0"),
                                model.UnionMember("b", "u32", "1"),
@@ -166,6 +181,7 @@ class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
                    ('c', prophy.r64, 2)]
 """
     assert ref == serialize(nodes)
+
 
 def test_of_PythonGenerator():
     ih = []

--- a/prophyc/tests/parsers/test_isar.py
+++ b/prophyc/tests/parsers/test_isar.py
@@ -5,8 +5,10 @@ from prophyc.parsers.isar import IsarParser
 from prophyc.parsers.isar import expand_operators
 from prophyc.file_processor import CyclicIncludeError, FileNotFoundError
 
-def parse(xml_string, process_file = lambda path: [], warn = None):
-    return IsarParser(warn = warn).parse(xml_string, '', process_file)
+
+def parse(xml_string, process_file=lambda path: [], warn=None):
+    return IsarParser(warn=warn).parse(xml_string, '', process_file)
+
 
 def test_includes_parsing():
     xml = """\
@@ -20,7 +22,7 @@ def test_includes_parsing():
     <xi:include href="noext"/>
 </system>
 """
-    nodes = parse(xml, process_file = lambda path: [model.Typedef("a", "u8")])
+    nodes = parse(xml, process_file=lambda path: [model.Typedef("a", "u8")])
 
     assert [
         ("mydlo", [model.Typedef("a", "u8")]),
@@ -31,6 +33,7 @@ def test_includes_parsing():
         ("../my.basename", [model.Typedef("a", "u8")]),
         ("noext", [model.Typedef("a", "u8")]),
     ] == nodes
+
 
 def test_includes_call_file_process_with_proper_path():
     xml = """\
@@ -44,9 +47,10 @@ def test_includes_call_file_process_with_proper_path():
         processed_paths.append(path)
         return []
 
-    parse(xml, process_file = process_file)
+    parse(xml, process_file=process_file)
 
     assert processed_paths == ['input.xml']
+
 
 def test_includes_cyclic_include_error():
     xml = """\
@@ -61,11 +65,12 @@ def test_includes_cyclic_include_error():
 
     nodes = parse(
         xml,
-        process_file = process_file_with_error,
-        warn = lambda msg: warnings.append(msg))
+        process_file=process_file_with_error,
+        warn=lambda msg: warnings.append(msg))
 
     assert nodes == [('input', [])]
     assert warnings == ['file input.xml included again during parsing']
+
 
 def test_includes_file_not_found_error():
     xml = """\
@@ -80,11 +85,12 @@ def test_includes_file_not_found_error():
 
     nodes = parse(
         xml,
-        process_file = process_file_with_error,
-        warn = lambda msg: warnings.append(msg))
+        process_file=process_file_with_error,
+        warn=lambda msg: warnings.append(msg))
 
     assert nodes == [('input', [])]
     assert warnings == ['file input.xml not found']
+
 
 def test_constants_parsing():
     xml = """\
@@ -96,6 +102,7 @@ def test_constants_parsing():
     nodes = parse(xml)
 
     assert [("CONST_A", "0"), ("CONST_B", "31")] == nodes
+
 
 def test_typedefs_primitive_type_parsing():
     xml = """\
@@ -125,6 +132,7 @@ def test_typedefs_primitive_type_parsing():
         model.Typedef("j", "r64")
     ]
 
+
 def test_typedefs_parsing():
     xml = """\
 <x>
@@ -132,6 +140,7 @@ def test_typedefs_parsing():
 </x>
 """
     assert parse(xml) == [model.Typedef("TILoveTypedefs_ALot", "MyType")]
+
 
 def test_enums_parsing():
     xml = """\
@@ -153,6 +162,7 @@ def test_enums_parsing():
         ])
     ]
 
+
 def test_enums_parsing_repeated_value():
     xml = """\
 <x>
@@ -165,6 +175,7 @@ def test_enums_parsing_repeated_value():
     with pytest.raises(ValueError) as e:
         parse(xml)
     assert "Duplicate Enum value" in str(e)
+
 
 def test_struct_parsing():
     xml = """\
@@ -187,6 +198,7 @@ def test_struct_parsing():
         ])
     ]
 
+
 def test_struct_parsing_with_constant():
     xml = """\
 <x>
@@ -202,6 +214,7 @@ def test_struct_parsing_with_constant():
         model.Struct("Struct", [model.StructMember("a", "u8")])
     ]
 
+
 def test_struct_parsing_dynamic_array():
     xml = """\
 <x>
@@ -215,9 +228,10 @@ def test_struct_parsing_dynamic_array():
     assert parse(xml) == [
         model.Struct("StructWithDynamic", [
             model.StructMember("x_len", "u32"),
-            model.StructMember("x", "TTypeX", bound = "x_len")
+            model.StructMember("x", "TTypeX", bound="x_len")
         ])
     ]
+
 
 def test_struct_parsing_static_array():
     xml = """\
@@ -231,9 +245,10 @@ def test_struct_parsing_static_array():
 """
     assert parse(xml) == [
         model.Struct("StructWithStatic", [
-            model.StructMember("y", "TTypeY", size = "NUM_OF_Y")
+            model.StructMember("y", "TTypeY", size="NUM_OF_Y")
         ])
     ]
+
 
 def test_struct_parsing_static_2d_array():
     xml = """\
@@ -247,9 +262,10 @@ def test_struct_parsing_static_2d_array():
 """
     assert parse(xml) == [
         model.Struct("StructWithStatic", [
-            model.StructMember("y", "TTypeY", size = "NUM_OF_Y*NUM_OF_X")
+            model.StructMember("y", "TTypeY", size="NUM_OF_Y*NUM_OF_X")
         ])
     ]
+
 
 def test_struct_parsing_dynamic_array_with_typed_sizer():
     xml = """\
@@ -264,9 +280,10 @@ def test_struct_parsing_dynamic_array_with_typed_sizer():
     assert parse(xml) == [
         model.Struct("StructX", [
             model.StructMember("x_len", "TNumberOfItems"),
-            model.StructMember("x", "TTypeX", bound = "x_len")
+            model.StructMember("x", "TTypeX", bound="x_len")
         ])
     ]
+
 
 def test_struct_parsing_dynamic_array_with_named_sizer():
     xml = """\
@@ -281,9 +298,10 @@ def test_struct_parsing_dynamic_array_with_named_sizer():
     assert parse(xml) == [
         model.Struct("StructX", [
             model.StructMember("numOfX", "u32"),
-            model.StructMember("x", "TTypeX", bound = "numOfX")
+            model.StructMember("x", "TTypeX", bound="numOfX")
         ])
     ]
+
 
 def test_struct_parsing_dynamic_array_with_named_and_typed_sizer():
     xml = """\
@@ -298,9 +316,10 @@ def test_struct_parsing_dynamic_array_with_named_and_typed_sizer():
     assert parse(xml) == [
         model.Struct("StructX", [
             model.StructMember("numOfX", "TSize"),
-            model.StructMember("x", "TTypeX", bound = "numOfX")
+            model.StructMember("x", "TTypeX", bound="numOfX")
         ])
     ]
+
 
 def test_isar_struct_parsing_ext_sized_array():
     xml = """\
@@ -324,11 +343,12 @@ def test_isar_struct_parsing_ext_sized_array():
         model.Struct("StructX", [
             model.StructMember("a", "u8"),
             model.StructMember("numOfZzz", "u16"),
-            model.StructMember("prophy_styled_x", "u16", bound = "a"),
-            model.StructMember("prophy_styled_y", "u16", bound = "a"),
-            model.StructMember("nativeIsarDefined", "u32", bound = "numOfNativeIsarDefined")
+            model.StructMember("prophy_styled_x", "u16", bound="a"),
+            model.StructMember("prophy_styled_y", "u16", bound="a"),
+            model.StructMember("nativeIsarDefined", "u32", bound="numOfNativeIsarDefined")
         ])
     ]
+
 
 def test_isar_message_parsing_with_ext_sized_arrays():
     xml = """\
@@ -361,12 +381,13 @@ def test_isar_message_parsing_with_ext_sized_arrays():
         model.Struct("StructX", [
             model.StructMember("a", "u8"),
             model.StructMember("numOfZzz", "u16"),
-            model.StructMember("prophy_styled_x", "u16", bound = "a"),
-            model.StructMember("prophy_styled_y", "DefA", bound = "a"),
-            model.StructMember("nativeIsarDefined", "DefA", bound = "numOfNativeIsarDefined"),
+            model.StructMember("prophy_styled_x", "u16", bound="a"),
+            model.StructMember("prophy_styled_y", "DefA", bound="a"),
+            model.StructMember("nativeIsarDefined", "DefA", bound="numOfNativeIsarDefined"),
             model.StructMember("dummy", "DefB")
         ])
     ]
+
 
 def test_struct_parsing_limited_array():
     xml = """\
@@ -381,9 +402,10 @@ def test_struct_parsing_limited_array():
     assert parse(xml) == [
         model.Struct("StructX", [
             model.StructMember("x_len", "u32"),
-            model.StructMember("x", "TTypeX", bound = "x_len", size = "3")
+            model.StructMember("x", "TTypeX", bound="x_len", size="3")
         ])
     ]
+
 
 def test_struct_parsing_with_optional():
     xml = """\
@@ -396,10 +418,11 @@ def test_struct_parsing_with_optional():
 """
     assert parse(xml) == [
         model.Struct("Struct", [
-            model.StructMember("a", "u8", optional = True),
-            model.StructMember("b", "u8", optional = False)
+            model.StructMember("a", "u8", optional=True),
+            model.StructMember("b", "u8", optional=False)
         ])
     ]
+
 
 def test_struct_parsing_with_optional_array():
     xml = """\
@@ -415,9 +438,10 @@ def test_struct_parsing_with_optional_array():
         model.Struct("X", [
             model.StructMember("has_a", "u32"),
             model.StructMember("a_len", "u32"),
-            model.StructMember("a", "A", bound = "a_len", size = "5")
+            model.StructMember("a", "A", bound="a_len", size="5")
         ])
     ]
+
 
 def test_message_parsing():
     xml = """\
@@ -432,6 +456,7 @@ def test_message_parsing():
             model.StructMember("x", "TTypeX")
         ])
     ]
+
 
 def test_struct_and_message_with_dynamic_array_parsing():
     xml = """\
@@ -450,13 +475,14 @@ def test_struct_and_message_with_dynamic_array_parsing():
     assert parse(xml) == [
         model.Struct("X", [
             model.StructMember("a_len", "u32"),
-            model.StructMember("a", "A", bound = "a_len", size = "5")
+            model.StructMember("a", "A", bound="a_len", size="5")
         ]),
         model.Struct("Y", [
             model.StructMember("b_len", "u32"),
-            model.StructMember("b", "B", bound = "b_len")
+            model.StructMember("b", "B", bound="b_len")
         ])
     ]
+
 
 def test_union_parsing():
     xml = """\
@@ -477,6 +503,7 @@ def test_union_parsing():
         model.UnionMember("c", "C", "5")
     ]
 
+
 def test_empty_elemens_parsing():
     xml = """\
 <x>
@@ -496,6 +523,7 @@ def test_empty_elemens_parsing():
 
     assert len(nodes) == 0
 
+
 def test_primitive_types():
     xml = """\
 <xml>
@@ -514,6 +542,7 @@ def test_primitive_types():
 """
     assert parse(xml) == [model.Typedef("ImNotAPrimitiveType", "u32")]
 
+
 def test_operator_expansion():
     assert expand_operators('bitMaskOr(1, 2)') == '((1) | (2))'
     assert expand_operators('shiftLeft(1, 2)') == '((1) << (2))'
@@ -523,6 +552,7 @@ def test_operator_expansion():
 
     assert (expand_operators('shiftLeft(bitMaskOr(1, 2), bitMaskOr(3, 4))') ==
             '((((1) | (2))) << (((3) | (4))))')
+
 
 def test_operator_expansion_in_enum_and_constant():
     xml = """\

--- a/prophyc/tests/parsers/test_prophy.py
+++ b/prophyc/tests/parsers/test_prophy.py
@@ -5,8 +5,10 @@ from prophyc.model import ParseError
 from prophyc.parsers.prophy import ProphyParser
 from prophyc.file_processor import CyclicIncludeError, FileNotFoundError
 
-def parse(content, parse_file = lambda path: []):
+
+def parse(content, parse_file=lambda path: []):
     return ProphyParser().parse(content, 'test.prophy', parse_file)
+
 
 def test_constants_parsing():
     content = """\
@@ -22,6 +24,7 @@ const CONST_D = -1;
         model.Constant("CONST_C", "25"),
         model.Constant("CONST_D", "-1")
     ]
+
 
 def test_constant_expressions():
     content = """\
@@ -40,6 +43,7 @@ const E = D << 2;
         model.Constant("E", "-12")
     ]
 
+
 def test_constant_expressions_errors():
     content = """\
 const A = 2 + C;
@@ -54,8 +58,10 @@ const C = 1 / 0;
         ("test.prophy:3:11", "division by zero")
     ]
 
+
 def test_constant_with_newline():
     assert parse("const \nCONST = 0;") == [model.Constant("CONST", "0")]
+
 
 def test_typedefs_parsing():
     content = """\
@@ -67,6 +73,7 @@ typedef x y;
         model.Typedef("x", "u32"),
         model.Typedef("y", "x")
     ]
+
 
 def test_enums_parsing():
     content = """\
@@ -93,6 +100,7 @@ enum enum2_t
         ])
     ]
 
+
 def test_structs_parsing():
     content = """\
 struct test
@@ -108,6 +116,7 @@ struct test
         ])
     ]
 
+
 def test_structs_with_fixed_array_parsing():
     content = """\
 const max = 5;
@@ -122,11 +131,12 @@ struct test
     assert parse(content) == [
         model.Constant('max', '5'),
         model.Struct('test', [
-            model.StructMember('x', 'u32', size = '3'),
-            model.StructMember('y', 'u32', size = '5'),
-            model.StructMember('z', 'byte', size = '10')
+            model.StructMember('x', 'u32', size='3'),
+            model.StructMember('y', 'u32', size='5'),
+            model.StructMember('z', 'byte', size='10')
         ])
     ]
+
 
 def test_structs_with_dynamic_array_parsing():
     content = """\
@@ -142,11 +152,12 @@ struct test
         model.Typedef('x_t', 'u32'),
         model.Struct('test', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'x_t', bound = 'num_of_x'),
+            model.StructMember('x', 'x_t', bound='num_of_x'),
             model.StructMember('num_of_y', 'u32'),
-            model.StructMember('y', 'byte', bound = 'num_of_y')
+            model.StructMember('y', 'byte', bound='num_of_y')
         ])
     ]
+
 
 def test_structs_with_dynamic_arrays_bounded_by_the_same_member_parsing():
     content = """\
@@ -165,10 +176,11 @@ struct test
         model.Struct('test', [
             model.StructMember('num_of_elements', 'u32'),
             model.StructMember('dummy', 'u16'),
-            model.StructMember('x', 'x_t', bound = 'num_of_elements'),
-            model.StructMember('y', 'byte', bound = 'num_of_elements')
+            model.StructMember('x', 'x_t', bound='num_of_elements'),
+            model.StructMember('y', 'byte', bound='num_of_elements')
         ])
     ]
+
 
 def test_structs_with_dynamic_arrays_bounded_by_the_same_member_parsing_typedef_sizer():
     content = """\
@@ -188,11 +200,12 @@ struct ExtSized
         model.Typedef('sz_t', 'num_of_elements_t'),
         model.Struct('ExtSized', [
             model.StructMember('sz', 'sz_t'),
-            model.StructMember('one', 'u32', bound = 'sz'),
-            model.StructMember('two', 'u16', bound = 'sz'),
-            model.StructMember('three', 'i32', bound = 'sz')
+            model.StructMember('one', 'u32', bound='sz'),
+            model.StructMember('two', 'u16', bound='sz'),
+            model.StructMember('three', 'i32', bound='sz')
         ])
     ]
+
 
 def test_structs_with_limited_array_parsing():
     content = """\
@@ -213,11 +226,12 @@ struct test
         ]),
         model.Struct('test', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u32', bound = 'num_of_x', size = '5'),
+            model.StructMember('x', 'u32', bound='num_of_x', size='5'),
             model.StructMember('num_of_y', 'u32'),
-            model.StructMember('y', 'u32', bound = 'num_of_y', size = '10')
+            model.StructMember('y', 'u32', bound='num_of_y', size='10')
         ])
     ]
+
 
 def test_structs_with_greedy_array_parsing():
     content = """\
@@ -229,9 +243,10 @@ struct test
 
     assert parse(content) == [
         model.Struct('test', [
-            model.StructMember('x', 'u32', unlimited = True)
+            model.StructMember('x', 'u32', unlimited=True)
         ])
     ]
+
 
 def test_structs_with_optional_field():
     content = """\
@@ -243,9 +258,10 @@ struct test
 
     assert parse(content) == [
         model.Struct('test', [
-            model.StructMember('x', 'u32', optional = True)
+            model.StructMember('x', 'u32', optional=True)
         ])
     ]
+
 
 def test_unions_parsing():
     content = """\
@@ -269,6 +285,7 @@ union test
         ])
     ]
 
+
 def test_floats_parsing():
     content = """\
 typedef float x;
@@ -285,23 +302,28 @@ struct z { float a; double b; };
         ])
     ]
 
+
 def test_lexer_error():
     with pytest.raises(ParseError) as e:
         parse('const ?')
     assert ":1:7", "illegal character '?'" == e.value.errors[0]
+
 
 def test_syntax_error():
     with pytest.raises(ParseError) as e:
         parse('const CONST badtoken')
     assert ":1:13", "syntax error at 'badtoken'" == e.value.errors[0]
 
+
 def test_unexpected_end_of_input():
     with pytest.raises(ParseError) as e:
         parse('const CONST = 0')
     assert ":1:15", "unexpected end of input" == e.value.errors[0]
 
+
 def test_no_error_with_newlines():
     assert len(parse('\nconst CONST1 = 0;\n\r\nconst CONST2 = 0;\n')) == 2
+
 
 def test_no_error_with_comments():
     assert len(parse("""\
@@ -315,15 +337,18 @@ const CONST4 = 0; /// ajisja
 const CONST5 = 0;
 """)) == 3
 
+
 def test_error_constant_text_value():
     with pytest.raises(ParseError) as e:
         parse('const CONST_X = wrong;')
     assert ":1:17", "constant 'wrong' was not declared" == e.value.errors[0]
 
+
 def test_error_constant_redefined():
     with pytest.raises(ParseError) as e:
         parse('const CONST = 1; const CONST_DIFFERENT = 1; const CONST = 1;')
     assert ":1:51", "name 'CONST' redefined" == e.value.errors[0]
+
 
 def test_error_constant_builtin_as_identifier():
     with pytest.raises(ParseError) as e:
@@ -333,15 +358,18 @@ def test_error_constant_builtin_as_identifier():
         parse('const bytes = 0;')
     assert ":1:7", "syntax error at 'bytes'" == e.value.errors[0]
 
+
 def test_error_typedef_redefined():
     with pytest.raises(ParseError) as e:
         parse('typedef u32 x; typedef u32 x;')
     assert ":1:28", "name 'x' redefined" == e.value.errors[0]
 
+
 def test_error_typedef_type_not_declared():
     with pytest.raises(ParseError) as e:
         parse('typedef x y;')
     assert ":1:9", "type 'x' was not declared" == e.value.errors[0]
+
 
 def test_error_typedef_builtin_as_identifier():
     with pytest.raises(ParseError) as e:
@@ -350,6 +378,7 @@ def test_error_typedef_builtin_as_identifier():
     with pytest.raises(ParseError) as e:
         parse('typedef u32 bytes;')
     assert ":1:13", "syntax error at 'bytes'" == e.value.errors[0]
+
 
 def test_error_enum_builtin_as_identifier():
     with pytest.raises(ParseError) as e:
@@ -362,6 +391,7 @@ def test_error_enum_builtin_as_identifier():
         parse('enum enum_t { enum_t_1 = u32 };')
     assert ":1:26", "syntax error at 'u32'" == e.value.errors[0]
 
+
 def test_error_enum_redefined():
     with pytest.raises(ParseError) as e:
         parse('const enum_t = 10; enum enum_t { enum_t_1 = 1 };')
@@ -373,13 +403,16 @@ def test_error_enum_redefined():
         parse('enum enum_t { enum_t_1 = 1 }; const enum_t_1 = 10; ')
     assert ":1:37", "name 'enum_t_1' redefined" == e.value.errors[0]
 
+
 def test_error_enum_constant_not_declared():
     with pytest.raises(ParseError) as e:
         parse('enum enum_t { enum_t_1 = unknown };')
     assert ":1:26", "constant 'unknown' was not declared" == e.value.errors[0]
 
+
 def test_no_error_enum_comment():
     assert len(parse('enum enum_t { enum_t_1 = 1, /* xxx */ enum_t_2 = 2 };')) == 1
+
 
 def test_error_struct_redefined():
     with pytest.raises(ParseError) as e:
@@ -389,15 +422,18 @@ def test_error_struct_redefined():
         parse('struct test { u32 x; }; struct test { u32 x; };')
     assert ":1:32", "name 'test' redefined" == e.value.errors[0]
 
+
 def test_error_struct_empty():
     with pytest.raises(ParseError) as e:
         parse('struct test {};')
     assert ":1:14", "syntax error at '}'" == e.value.errors[0]
 
+
 def test_error_struct_empty_2():
     with pytest.raises(ParseError) as e:
         parse('struct test { u32 <@b>;};')
     assert ":1:14", "syntax error at '}'" == e.value.errors[0]
+
 
 def test_error_struct_repeated_field_names():
     with pytest.raises(ParseError) as e:
@@ -434,14 +470,17 @@ struct test
 };""")
     assert ":4:9", "field 'x' redefined" == e.value.errors[0]
 
+
 def test_no_error_struct_comments_between_newlines():
     assert len(parse('struct test { u32 x; /* \n u32 y; \n */ \n u32 z; };')) == 1
     assert len(parse('struct test { u32 x; // xxxx \n u32 y; \n // u32 z; \n };')) == 1
+
 
 def test_error_struct_field_type_not_declared():
     with pytest.raises(ParseError) as e:
         parse('struct test { unknown x; };')
     assert ":1:15", "type 'unknown' was not declared" == e.value.errors[0]
+
 
 def test_error_struct_array_size_not_declared():
     with pytest.raises(ParseError) as e:
@@ -450,6 +489,7 @@ def test_error_struct_array_size_not_declared():
     with pytest.raises(ParseError) as e:
         parse('struct test { u32 x<unknown>; };')
     assert ":1:21", "constant 'unknown' was not declared" == e.value.errors[0]
+
 
 def test_error_struct_array_size_cannot_be_negative():
     with pytest.raises(ParseError) as e:
@@ -468,6 +508,7 @@ def test_error_struct_array_size_cannot_be_negative():
         parse('struct test { u32 x[1-2]; };')
     assert ":1:21", "array size '-1' non-positive" == e.value.errors[0]
 
+
 def test_error_struct_sizer_of_dynamic_array_is_not_defined_before():
     with pytest.raises(ParseError) as e:
         parse('struct test { u32 x<@sz>; u32 sz; };')
@@ -477,15 +518,18 @@ def test_error_struct_sizer_of_dynamic_array_is_not_defined_before():
         parse('const sz = 10; struct test { u32 x<@sz>;};')
     assert ":1:34", "Sizer of 'x' has to be defined before the array" == e.value.errors[0]
 
+
 def test_error_struct_sizer_of_dynamic_array_is_not_of_integer_type():
     with pytest.raises(ParseError) as e:
         parse('struct X { u32 s; }; struct test { X sz; u32 x<@sz>; };')
     assert ":1:46", "Sizer of 'x' has to be of (unsigned) integer type" == e.value.errors[0]
 
+
 def test_error_struct_greedy_field_is_not_the_last_one():
     with pytest.raises(ParseError) as e:
         parse('struct test { u32 x<...>; u32 y; };')
     assert ":1:19", "greedy array field 'x' not last" == e.value.errors[0]
+
 
 def test_error_union_redefined():
     with pytest.raises(ParseError) as e:
@@ -495,30 +539,36 @@ def test_error_union_redefined():
         parse('union test { 1: u32 x; }; union test { 1: u32 x; };')
     assert ":1:33", "name 'test' redefined" == e.value.errors[0]
 
+
 def test_error_union_empty():
     with pytest.raises(ParseError) as e:
         parse('union test {};')
     assert ":1:13", "syntax error at '}'" == e.value.errors[0]
+
 
 def test_error_union_repeated_arm_name():
     with pytest.raises(ParseError) as e:
         parse('union test { 1: u32 x; 2: u32 x; };')
     assert ":1:31", "field 'x' redefined" == e.value.errors[0]
 
+
 def test_error_union_repeated_arm_discriminator():
     with pytest.raises(ParseError) as e:
         parse('union test { 1: u32 x; 1: u32 y; };')
     assert ":1:31", "duplicate discriminator value '1'" == e.value.errors[0]
+
 
 def test_error_union_field_type_not_declared():
     with pytest.raises(ParseError) as e:
         parse('union test { 1: dontknow x };')
     assert ":1:17", "type 'dontknow' was not declared" == e.value.errors[0]
 
+
 def test_error_union_discriminator_not_declared():
     with pytest.raises(ParseError) as e:
         parse('union test { unknown: u32 x; };')
     assert ":1:14", "constant 'unknown' was not declared" == e.value.errors[0]
+
 
 def test_multiple_errors():
     with pytest.raises(ParseError) as e:
@@ -533,10 +583,12 @@ const Z 2;
         ("test.prophy:3:9", "syntax error at '2'")
     ]
 
+
 def test_typedef_cross_referenced_definition():
     typedef = parse("struct X { u32 x; }; typedef X Y;")[1]
     assert type(typedef.definition) == model.Struct
     assert typedef.definition.name == 'X'
+
 
 def test_struct_member_cross_referenced_definition():
     members = parse("""\
@@ -561,6 +613,7 @@ struct Y
     assert type(members[6].definition) == model.Typedef
     assert type(members[7].definition) == model.Typedef
     assert type(members[8].definition) == model.Typedef
+
 
 def test_struct_kinds():
     structs = parse("""\
@@ -591,20 +644,24 @@ struct Y4 { X4 x; };
     assert structs[6].members[0].kind == model.Kind.UNLIMITED
     assert structs[7].members[0].kind == model.Kind.DYNAMIC
 
+
 def test_error_struct_non_last_field_has_unlimited_kind():
     with pytest.raises(ParseError) as e:
         parse("struct X { u32 x<...>; }; struct Y { X x; u32 y; };")
     assert ":1:40", "greedy array field 'x' not last" == e.value.errors[0]
+
 
 def test_error_union_member_has_dynamic_kind():
     with pytest.raises(ParseError) as e:
         parse("struct X { u32 x<>; }; union Y { 0: X x; };")
     assert ":1:39", "dynamic union arm 'x'" == e.value.errors[0]
 
+
 def test_error_union_member_has_unlimited_kind():
     with pytest.raises(ParseError) as e:
         parse("struct X { u32 x<...>; }; union Y { 0: X x; };")
     assert ":1:42", "dynamic union arm 'x'" == e.value.errors[0]
+
 
 def test_include_path():
     assert parse('#include "x.prophy"') == [model.Include('x', [])]
@@ -617,6 +674,7 @@ def test_include_path():
     assert parse(' # include  "x.prophy" ') == [model.Include('x', [])]
     assert parse('\n#\ninclude\n"x.prophy"\n') == [model.Include('x', [])]
 
+
 def test_include_path_errors():
     with pytest.raises(ParseError) as e:
         parse('#notinclude "test"')
@@ -625,6 +683,7 @@ def test_include_path_errors():
         parse('#include <test>')
     assert e.value.errors == [("test.prophy:1:10", "syntax error at '<'")]
 
+
 def test_include_no_error_with_constant():
     content = """\
 #include "test.prophy"
@@ -632,12 +691,14 @@ const Y = X;
 """
     parse(content, lambda path: [model.Constant('X', '42')])
 
+
 def test_include_no_error_with_typedef():
     content = """\
 #include "test.prophy"
 typedef X Y;
 """
     parse(content, lambda path: [model.Typedef('X', 'u32')])
+
 
 def test_include_no_error_with_enum():
     content = """\
@@ -647,6 +708,7 @@ const Z = X1;
 """
     parse(content, lambda path: [model.Enum('X', [model.EnumMember('X1', '1')])])
 
+
 def test_include_no_error_with_struct():
     content = """\
 #include "test.prophy"
@@ -654,12 +716,14 @@ typedef X Y;
 """
     parse(content, lambda path: [model.Struct('X', [])])
 
+
 def test_include_no_error_with_union():
     content = """\
 #include "test.prophy"
 typedef X Y;
 """
     parse(content, lambda path: [model.Union('X', [])])
+
 
 def test_include_errors():
     with pytest.raises(ParseError) as e:

--- a/prophyc/tests/parsers/test_prophy.py
+++ b/prophyc/tests/parsers/test_prophy.py
@@ -6,7 +6,7 @@ from prophyc.parsers.prophy import ProphyParser
 from prophyc.file_processor import CyclicIncludeError, FileNotFoundError
 
 
-def parse(content, parse_file=lambda path: []):
+def parse(content, parse_file=lambda _: []):
     return ProphyParser().parse(content, 'test.prophy', parse_file)
 
 

--- a/prophyc/tests/parsers/test_prophy.py
+++ b/prophyc/tests/parsers/test_prophy.py
@@ -33,6 +33,7 @@ const B = A * 2;
 const C = (B - A) * 3;
 const D = -C;
 const E = D << 2;
+const F = 0xF >> (E + 10 + C);
 """
 
     assert parse(content) == [
@@ -40,7 +41,8 @@ const E = D << 2;
         model.Constant("B", "2"),
         model.Constant("C", "3"),
         model.Constant("D", "-3"),
-        model.Constant("E", "-12")
+        model.Constant("E", "-12"),
+        model.Constant("F", "7")
     ]
 
 

--- a/prophyc/tests/parsers/test_sack.py
+++ b/prophyc/tests/parsers/test_sack.py
@@ -2,10 +2,12 @@ import pytest
 
 from prophyc import model
 
+
 def parse(content, extension='.hpp', warn=None, includes=[]):
     from prophyc.parsers.sack import SackParser
     file_name = 'test'
     return SackParser(warn=warn, include_dirs=includes).parse(content, file_name + extension, None)
+
 
 class contains_cmp(object):
     def __init__(self, x):
@@ -13,6 +15,7 @@ class contains_cmp(object):
 
     def __eq__(self, other):
         return any((self.x in other, other in self.x))
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -33,6 +36,7 @@ struct X
             model.StructMember("c", "u32")
         ])
     ]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -78,6 +82,7 @@ struct X
         ])
     ]
 
+
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
 def test_nested_typedefs(extension):
@@ -91,6 +96,7 @@ struct X
 };
 """
     assert parse(hpp, extension) == [model.Struct("X", [model.StructMember("a", "i32")])]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -110,6 +116,7 @@ struct X
         model.Struct("OldStruct", [model.StructMember("a", "u32")]),
         model.Struct("X", [model.StructMember("a", "OldStruct")])
     ]
+
 
 @pytest.clang_installed
 def test_namespaced_struct():
@@ -135,6 +142,7 @@ struct X
         model.Struct("X", [model.StructMember("a", "m__n__Namespaced")])
     ]
 
+
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
 def test_array(extension):
@@ -150,6 +158,7 @@ struct X
             model.StructMember("a", "u32", size=4)
         ])
     ]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -177,6 +186,7 @@ struct X
         ])
     ]
 
+
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
 def test_typedefed_enum(extension):
@@ -202,6 +212,7 @@ struct X
             model.StructMember("a", "Enum")
         ])
     ]
+
 
 @pytest.clang_installed
 def test_namespaced_enum():
@@ -234,6 +245,7 @@ struct X
         ])
     ]
 
+
 @pytest.clang_installed
 def test_namespaced_typedef():
     hpp = """\
@@ -249,6 +261,7 @@ struct X
             model.StructMember('x', 'u32')
         ])
     ]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -275,6 +288,7 @@ struct X
             model.StructMember("a", "Enum")
         ])
     ]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -306,6 +320,7 @@ struct X
         ])
     ]
 
+
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
 def test_c_enum(extension):
@@ -331,6 +346,7 @@ struct X
             model.StructMember("a", "Enum")
         ])
     ]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -359,6 +375,7 @@ struct X
         ])
     ]
 
+
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
 def test_typedefed_union(extension):
@@ -381,6 +398,7 @@ struct X
             model.StructMember("a", "Union")
         ])
     ]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -414,6 +432,7 @@ struct Z
         ])
     ]
 
+
 @pytest.clang_installed
 def test_class_template():
     hpp = """\
@@ -443,6 +462,7 @@ struct X
         ])
     ]
 
+
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
 def test_c_struct(extension):
@@ -464,6 +484,7 @@ typedef struct X X;
             model.StructMember("x", "i32")
         ])
     ]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -487,6 +508,7 @@ struct X
         ])
     ]
 
+
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
 def test_struct_with_incomplete_array(extension):
@@ -501,6 +523,7 @@ struct X
             model.StructMember('b', 'i8')
         ])
     ]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -518,6 +541,7 @@ struct X
 
     assert '__test__' + extension[1:] + '__' in nodes[0].name
 
+
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
 def test_forward_declared_struct(extension):
@@ -525,6 +549,7 @@ def test_forward_declared_struct(extension):
 struct X;
 """
     assert parse(hpp, extension) == []
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed
@@ -540,12 +565,14 @@ struct X
 """
     assert parse(hpp, extension) == [model.Struct('X', [])]
 
+
 class WarnMock(object):
     def __init__(self):
         self.warnings = []
 
     def __call__(self, msg, location='prophyc'):
         self.warnings.append((location, msg))
+
 
 @pytest.mark.parametrize('extension, expected', [
     ('.c', 'type specifier missing, defaults to \'int\''),
@@ -563,6 +590,7 @@ unknown;
                  warn=warn) == []
     assert warn.warnings == [('test' + extension + ':1:1', expected)]
 
+
 @pytest.mark.parametrize('extension', [('.c'), ('.cpp')])
 @pytest.clang_installed
 def test_diagnostics_warning(extension):
@@ -579,11 +607,13 @@ int foo()
                  warn=warn) == []
     assert warn.warnings == [('test' + extension + ':4:1', 'control reaches end of non-void function')]
 
+
 @pytest.clang_installed
 def test_libclang_parsing_error():
     with pytest.raises(model.ParseError) as e:
         parse('content', '')
     assert e.value.errors == [('test', 'error parsing translation unit')]
+
 
 @pytest.mark.parametrize('extension', [('.h'), ('.hpp')])
 @pytest.clang_installed

--- a/prophyc/tests/test_calc.py
+++ b/prophyc/tests/test_calc.py
@@ -1,6 +1,7 @@
 import pytest
 from prophyc import calc
 
+
 def test_calc_numeric():
     assert calc.eval('10 + 2', {}) == 12
     assert calc.eval('10 - 2', {}) == 8
@@ -9,15 +10,19 @@ def test_calc_numeric():
     assert calc.eval('10 << 2', {}) == 40
     assert calc.eval('10 >> 2', {}) == 2
 
+
 def test_calc_parens():
     assert calc.eval('10 + 2 * 3', {}) == 16
     assert calc.eval('(10 + 2) * 3', {}) == 36
 
+
 def test_calc_variables():
     assert calc.eval('a + b', {'a': 2, 'b': 3}) == 5
 
+
 def test_calc_nested_variables():
     assert calc.eval('a', {'a': 'b', 'b': 'c', 'c': 9}) == 9
+
 
 def test_calc_errors():
     with pytest.raises(calc.ParseError) as e:

--- a/prophyc/tests/test_calc.py
+++ b/prophyc/tests/test_calc.py
@@ -9,6 +9,8 @@ def test_calc_numeric():
     assert calc.eval('10 / 2', {}) == 5
     assert calc.eval('10 << 2', {}) == 40
     assert calc.eval('10 >> 2', {}) == 2
+    assert calc.eval('-10', {}) == -10
+    assert calc.eval('\n-10\n', {}) == -10
 
 
 def test_calc_parens():

--- a/prophyc/tests/test_file_processor.py
+++ b/prophyc/tests/test_file_processor.py
@@ -3,6 +3,7 @@ import re
 import pytest
 from prophyc.file_processor import FileProcessor, CyclicIncludeError, FileNotFoundError
 
+
 class FakeContentProcessor(object):
 
     def __init__(self):
@@ -20,15 +21,18 @@ class FakeContentProcessor(object):
                 out += line + '\n'
         return out
 
+
 def test_file_processor_single_curdir(tmpdir_cwd):
     tmpdir_cwd.join('input.txt').write('the input\n')
     assert FileProcessor(FakeContentProcessor(), [])('input.txt') == 'the input\n'
+
 
 def test_file_processor_single_nestdir(tmpdir_cwd):
     os.mkdir('x')
     tmpdir_cwd.join('x/input.txt').write('nest input\n')
 
     assert FileProcessor(FakeContentProcessor(), [])('x/input.txt') == 'nest input\n'
+
 
 def test_file_processor_include_dirs(tmpdir_cwd):
     os.mkdir('x')
@@ -44,10 +48,12 @@ one input
 other input
 '''
 
+
 def test_file_processor_main_file_not_found(tmpdir_cwd):
     with pytest.raises(FileNotFoundError) as e:
         FileProcessor(FakeContentProcessor(), [])('nonexistent.txt')
     assert str(e.value) == 'file nonexistent.txt not found'
+
 
 def test_file_processor_include_file_not_found(tmpdir_cwd):
     os.mkdir('x')
@@ -57,11 +63,13 @@ def test_file_processor_include_file_not_found(tmpdir_cwd):
         FileProcessor(FakeContentProcessor(), [])('main.txt')
     assert str(e.value) == 'file incl.txt not found'
 
+
 def test_file_processor_main_self_include(tmpdir_cwd):
     tmpdir_cwd.join('main.txt').write('#include <main.txt>')
     with pytest.raises(CyclicIncludeError) as e:
         FileProcessor(FakeContentProcessor(), [])('main.txt')
     assert str(e.value) == 'file main.txt included again during parsing'
+
 
 def test_file_processor_leaf_self_include(tmpdir_cwd):
     tmpdir_cwd.join('main.txt').write('#include <incl.txt>')
@@ -70,6 +78,7 @@ def test_file_processor_leaf_self_include(tmpdir_cwd):
         FileProcessor(FakeContentProcessor(), [])('main.txt')
     assert str(e.value) == 'file incl.txt included again during parsing'
 
+
 def test_file_processor_cyclic_include(tmpdir_cwd):
     tmpdir_cwd.join('main.txt').write('#include <incl1.txt>')
     tmpdir_cwd.join('incl1.txt').write('#include <incl2.txt>')
@@ -77,6 +86,7 @@ def test_file_processor_cyclic_include(tmpdir_cwd):
     with pytest.raises(CyclicIncludeError) as e:
         FileProcessor(FakeContentProcessor(), [])('main.txt')
     assert str(e.value) == 'file incl1.txt included again during parsing'
+
 
 def test_file_processor_include_dir_precedence(tmpdir_cwd):
     os.mkdir('x')
@@ -96,6 +106,7 @@ def test_file_processor_include_dir_precedence(tmpdir_cwd):
     tmpdir_cwd.join('z/incl.txt').write('third')
     assert process() == 'third\n'
 
+
 def test_file_processor_nested_includes(tmpdir_cwd):
     tmpdir_cwd.join('main.txt').write('#include <incl1.txt>')
     tmpdir_cwd.join('incl1.txt').write('#include <incl2.txt>')
@@ -103,6 +114,7 @@ def test_file_processor_nested_includes(tmpdir_cwd):
     tmpdir_cwd.join('incl3.txt').write('some text')
 
     assert FileProcessor(FakeContentProcessor(), ['.'])('main.txt') == 'some text\n'
+
 
 def test_file_processor_include_already_parsed(tmpdir_cwd):
     tmpdir_cwd.join('main.txt').write('''\
@@ -116,6 +128,7 @@ def test_file_processor_include_already_parsed(tmpdir_cwd):
     assert FileProcessor(fake, ['.'])('main.txt') == 'text\ntext\ntext\n'
     assert fake.calls == 2
 
+
 def test_file_processor_multisegment_paths(tmpdir_cwd):
     os.makedirs('proj/include/x/y')
     tmpdir_cwd.join('proj/main.txt').write('''\
@@ -128,6 +141,7 @@ def test_file_processor_multisegment_paths(tmpdir_cwd):
     tmpdir_cwd.join('proj/include/x/y/c.txt').write('three')
     assert FileProcessor(FakeContentProcessor(), ['proj/include'])('proj/main.txt') == 'one\ntwo\nthree\n'
 
+
 def test_file_processor_main_directory_is_an_implicit_include_directory(tmpdir_cwd):
     os.mkdir('x')
     tmpdir_cwd.join('main.txt').write('#include <incl1.txt>')
@@ -135,6 +149,7 @@ def test_file_processor_main_directory_is_an_implicit_include_directory(tmpdir_c
     tmpdir_cwd.join('x/incl1.txt').write('wrong text')
 
     assert FileProcessor(FakeContentProcessor(), ['x'])('main.txt') == 'some text\n'
+
 
 def test_file_processor_main_directory_implicit_include_directory_taken_over_by_successive_calls(tmpdir_cwd):
     os.mkdir('x')
@@ -150,6 +165,7 @@ def test_file_processor_main_directory_implicit_include_directory_taken_over_by_
         processor('x/main2.txt')
     assert str(e.value) == 'file incl2.txt not found'
 
+
 def test_file_processor_leaf_directory_takes_over_as_an_implicit_include_directory(tmpdir_cwd):
     os.makedirs('x/y/z')
     tmpdir_cwd.join('main.txt').write('#include <x/incl1.txt>')
@@ -158,6 +174,7 @@ def test_file_processor_leaf_directory_takes_over_as_an_implicit_include_directo
     tmpdir_cwd.join('x/y/z/incl3.txt').write('some text')
 
     assert FileProcessor(FakeContentProcessor(), [])('main.txt') == 'some text\n'
+
 
 def test_file_processor_leaf_directory_takes_over_as_an_implicit_include_directory_error(tmpdir_cwd):
     os.mkdir('x')

--- a/prophyc/tests/test_model.py
+++ b/prophyc/tests/test_model.py
@@ -1,17 +1,19 @@
 from prophyc import model
 
+
 def test_typedef_repr():
     typedef = model.Typedef("my_typedef", "u8")
     assert str(typedef) == "u8 my_typedef"
 
+
 def test_struct_repr():
     struct = model.Struct("MyStruct", [
         model.StructMember("a", "u8"),
-        model.StructMember("b", "u16", bound = 'xlen'),
-        model.StructMember("c", "u32", size = 5),
-        model.StructMember("d", "u64", bound = 'xlen', size = 5),
-        model.StructMember("e", "UU", unlimited = True),
-        model.StructMember("f", "UUUU", optional = True)
+        model.StructMember("b", "u16", bound='xlen'),
+        model.StructMember("c", "u32", size=5),
+        model.StructMember("d", "u64", bound='xlen', size=5),
+        model.StructMember("e", "UU", unlimited=True),
+        model.StructMember("f", "UUUU", optional=True)
     ])
     assert str(struct) == """\
 MyStruct
@@ -22,6 +24,7 @@ MyStruct
     UU e<...>
     UUUU* f
 """
+
 
 def test_union_repr():
     union = model.Union("MyUnion", [
@@ -39,9 +42,11 @@ MyUnion
     3: u32 c
 """
 
+
 def test_split_after():
     generator = model.split_after([1, 42, 2, 3, 42, 42, 5], lambda x: x == 42)
     assert [x for x in generator] == [[1, 42], [2, 3, 42], [42], [5]]
+
 
 def test_model_sort_enums():
     nodes = [model.Typedef("B", "A"),
@@ -51,6 +56,7 @@ def test_model_sort_enums():
     model.topological_sort(nodes)
 
     assert ["A", "B", "C"] == [node.name for node in nodes]
+
 
 def test_model_sort_typedefs():
     nodes = [model.Typedef("A", "X"),
@@ -62,6 +68,7 @@ def test_model_sort_typedefs():
     model.topological_sort(nodes)
 
     assert ["A", "B", "C", "D", "E"] == [node.name for node in nodes]
+
 
 def test_model_sort_structs():
     nodes = [model.Struct("C", [model.StructMember("a", "B"),
@@ -78,6 +85,7 @@ def test_model_sort_structs():
 
     assert ["A", "B", "C"] == [node.name for node in nodes]
 
+
 def test_model_sort_struct_with_two_deps():
     nodes = [model.Struct("C", [model.StructMember("a", "B")]),
              model.Struct("B", [model.StructMember("a", "A")]),
@@ -86,6 +94,7 @@ def test_model_sort_struct_with_two_deps():
     model.topological_sort(nodes)
 
     assert ["A", "B", "C"] == [node.name for node in nodes]
+
 
 def test_model_sort_struct_with_multiple_dependencies():
     nodes = [model.Struct("D", [model.StructMember("a", "A"),
@@ -100,6 +109,7 @@ def test_model_sort_struct_with_multiple_dependencies():
 
     assert ["A", "B", "C", "D"] == [node.name for node in nodes]
 
+
 def test_model_sort_union():
     nodes = [model.Typedef("C", "B"),
              model.Union("B", [model.UnionMember("a", "A", "0"),
@@ -110,6 +120,7 @@ def test_model_sort_union():
 
     assert ["A", "B", "C"] == [node.name for node in nodes]
 
+
 def test_model_sort_constants():
     nodes = [model.Constant("C_C", "C_A + C_B"),
              model.Constant("C_A", "1"),
@@ -118,6 +129,7 @@ def test_model_sort_constants():
     model.topological_sort(nodes)
 
     assert [("C_A", "1"), ("C_B", "2"), ("C_C", "C_A + C_B")] == nodes
+
 
 def test_cross_reference_structs():
     nodes = [
@@ -150,6 +162,7 @@ def test_cross_reference_structs():
         ['A', 'B', 'C']
     ]
 
+
 def test_cross_reference_typedef():
     nodes = [
         model.Struct("A", [
@@ -169,6 +182,7 @@ def test_cross_reference_typedef():
     assert nodes[2].members[1].definition.definition.name == "A"
     assert nodes[3].definition.name == "B"
     assert nodes[3].definition.definition.name == "A"
+
 
 def test_cross_symbols_from_includes():
     nodes = [
@@ -193,6 +207,7 @@ def test_cross_symbols_from_includes():
     # cross-reference only needs to link definitions of first level of nodes
     assert nodes[0].nodes[1].members[0].definition is None
 
+
 def test_cross_reference_array_size_from_includes():
     nodes = [
         model.Include('x', [
@@ -205,10 +220,10 @@ def test_cross_reference_array_size_from_includes():
             ]),
         ]),
         model.Struct('X', [
-            model.StructMember('x', 'u32', size = 'NUM'),
-            model.StructMember('y', 'u32', size = 'E1'),
-            model.StructMember('z', 'u32', size = 'UNKNOWN'),
-            model.StructMember('a', 'u32', size = 'E3')
+            model.StructMember('x', 'u32', size='NUM'),
+            model.StructMember('y', 'u32', size='E1'),
+            model.StructMember('z', 'u32', size='UNKNOWN'),
+            model.StructMember('a', 'u32', size='E3')
         ])
     ]
 
@@ -219,13 +234,14 @@ def test_cross_reference_array_size_from_includes():
     assert nodes[1].members[2].numeric_size is None
     assert nodes[1].members[3].numeric_size == 3
 
+
 def test_cross_reference_numeric_size_of_expression():
     nodes = [
         model.Constant('A', 12),
         model.Constant('B', 15),
         model.Constant('C', 'A*B'),
         model.Struct('X', [
-            model.StructMember('x', 'u32', size = 'C'),
+            model.StructMember('x', 'u32', size='C'),
         ])
     ]
 
@@ -233,16 +249,18 @@ def test_cross_reference_numeric_size_of_expression():
 
     assert nodes[3].members[0].numeric_size == 180
 
+
 def test_cross_reference_expression_as_array_size():
     nodes = [
         model.Struct('X', [
-            model.StructMember('x', 'u32', size = '2 * 3'),
+            model.StructMember('x', 'u32', size='2 * 3'),
         ])
     ]
 
     model.cross_reference(nodes)
 
     assert nodes[0].members[0].numeric_size == 6
+
 
 class WarnFake(object):
     def __init__(self):
@@ -251,23 +269,27 @@ class WarnFake(object):
     def __call__(self, msg):
         self.msgs.append(msg)
 
+
 def test_cross_reference_typedef_warnings():
     nodes = [model.Typedef('X', 'Unknown')]
     warn = WarnFake()
     model.cross_reference(nodes, warn)
     assert warn.msgs == ["type 'Unknown' not found"]
 
+
 def test_cross_reference_struct_warnings():
-    nodes = [model.Struct('X', [model.StructMember('x', 'TypeUnknown', size = '12 + NumUnknown')])]
+    nodes = [model.Struct('X', [model.StructMember('x', 'TypeUnknown', size='12 + NumUnknown')])]
     warn = WarnFake()
     model.cross_reference(nodes, warn)
     assert warn.msgs == ["type 'TypeUnknown' not found", "numeric constant 'NumUnknown' not found"]
+
 
 def test_cross_reference_union_warnings():
     nodes = [model.Union('X', [model.UnionMember('x', 'TypeUnknown', '42')])]
     warn = WarnFake()
     model.cross_reference(nodes, warn)
     assert warn.msgs == ["type 'TypeUnknown' not found"]
+
 
 def test_cross_reference_no_warning_about_primitive_types():
     warn = WarnFake()
@@ -284,6 +306,7 @@ def test_cross_reference_no_warning_about_primitive_types():
     model.cross_reference([model.Typedef('X', 'byte')], warn)
     assert warn.msgs == []
 
+
 def test_cross_reference_quadratic_complexity_include_performance_bug():
     """
     If type and numeric definitions from includes are processed each time,
@@ -294,24 +317,25 @@ def test_cross_reference_quadratic_complexity_include_performance_bug():
     nodes = [model.Constant('X', 42), model.Typedef('Y', 'u8')] * FACTOR
     for i in range(FACTOR):
         nodes = [model.Include('inc%s' % i, nodes)] * FACTOR
-    nodes.append(model.Struct('Z', [model.StructMember('x', 'u8', size = 'X')]))
+    nodes.append(model.Struct('Z', [model.StructMember('x', 'u8', size='X')]))
 
     """This line will kill your cpu if cross-referencing algorithm is quadratic"""
     model.cross_reference(nodes)
 
     assert nodes[-1].members[0].numeric_size == 42
 
+
 def test_evaluate_kinds_arrays():
     nodes = [
         model.Struct("A", [
             model.StructMember("a", "u8"),
-            model.StructMember("b", "u8", optional = True),
-            model.StructMember("c", "u8", size = "5"),
+            model.StructMember("b", "u8", optional=True),
+            model.StructMember("c", "u8", size="5"),
             model.StructMember("d_len", "u8"),
-            model.StructMember("d", "u8", bound = "d_len", size = "5"),
+            model.StructMember("d", "u8", bound="d_len", size="5"),
             model.StructMember("e_len", "u8"),
-            model.StructMember("e", "u8", bound = "e_len"),
-            model.StructMember("f", "u8", unlimited = True)
+            model.StructMember("e", "u8", bound="e_len"),
+            model.StructMember("f", "u8", unlimited=True)
         ])
     ]
 
@@ -329,6 +353,7 @@ def test_evaluate_kinds_arrays():
         model.Kind.FIXED,
     ]
 
+
 def test_evaluate_kinds_struct_records():
     nodes = [
         model.Struct("Fix", [
@@ -336,13 +361,13 @@ def test_evaluate_kinds_struct_records():
         ]),
         model.Struct("Dyn", [
             model.StructMember("a_len", "u8"),
-            model.StructMember("a", "u8", bound = "a_len")
+            model.StructMember("a", "u8", bound="a_len")
         ]),
         model.Struct("X", [
             model.StructMember("a", "Dyn"),
             model.StructMember("b_len", "u8"),
-            model.StructMember("b", "Fix", bound = "b_len"),
-            model.StructMember("c", "Fix", unlimited = True)
+            model.StructMember("b", "Fix", bound="b_len"),
+            model.StructMember("c", "Fix", unlimited=True)
         ])
     ]
 
@@ -362,22 +387,23 @@ def test_evaluate_kinds_struct_records():
         model.Kind.FIXED,
     ]
 
+
 def test_evaluate_kinds_with_typedefs():
     nodes = [
         model.Struct("Empty", []),
         model.Struct("Dynamic", [
             model.StructMember("a_len", "u8"),
-            model.StructMember("a", "u8", bound = "a_len")
+            model.StructMember("a", "u8", bound="a_len")
         ]),
         model.Struct("Fixed", [
-            model.StructMember("a", "u8", size = "10")
+            model.StructMember("a", "u8", size="10")
         ]),
         model.Struct("Limited", [
             model.StructMember("a_len", "u8"),
-            model.StructMember("a", "u8", bound = "a_len", size = "10")
+            model.StructMember("a", "u8", bound="a_len", size="10")
         ]),
         model.Struct("Greedy", [
-            model.StructMember("a", "byte", unlimited = True)
+            model.StructMember("a", "byte", unlimited=True)
         ]),
         model.Struct("DynamicWrapper", [
             model.StructMember("a", "Dynamic")
@@ -386,7 +412,7 @@ def test_evaluate_kinds_with_typedefs():
             model.StructMember("a", "Greedy")
         ]),
         model.Struct("GreedyDynamic", [
-            model.StructMember("a", "Dynamic", unlimited = True)
+            model.StructMember("a", "Dynamic", unlimited=True)
         ]),
         model.Typedef("TU8", "u8"),
         model.Typedef("TDynamic", "Dynamic"),
@@ -425,6 +451,7 @@ def test_evaluate_kinds_with_typedefs():
         model.Kind.DYNAMIC,
     ]
 
+
 def test_partition_fixed():
     nodes = [
         model.Struct("Fixed", [
@@ -441,15 +468,16 @@ def test_partition_fixed():
     assert [x.name for x in main] == ["a", "b", "c"]
     assert [[x.name for x in part] for part in parts] == []
 
+
 def test_partition_many_arrays():
     nodes = [
         model.Struct("ManyArrays", [
             model.StructMember("num_of_a", "u8"),
-            model.StructMember("a", "u8", bound = "num_of_a"),
+            model.StructMember("a", "u8", bound="num_of_a"),
             model.StructMember("num_of_b", "u8"),
-            model.StructMember("b", "u8", bound = "num_of_b"),
+            model.StructMember("b", "u8", bound="num_of_b"),
             model.StructMember("num_of_c", "u8"),
-            model.StructMember("c", "u8", bound = "num_of_c")
+            model.StructMember("c", "u8", bound="num_of_c")
         ]),
     ]
 
@@ -460,13 +488,14 @@ def test_partition_many_arrays():
     assert [x.name for x in main] == ["num_of_a", "a"]
     assert [[x.name for x in part] for part in parts] == [["num_of_b", "b"], ["num_of_c", "c"]]
 
+
 def test_partition_many_arrays_mixed():
     nodes = [
         model.Struct("ManyArraysMixed", [
             model.StructMember("num_of_a", "u8"),
             model.StructMember("num_of_b", "u8"),
-            model.StructMember("a", "u8", bound = "num_of_a"),
-            model.StructMember("b", "u8", bound = "num_of_b")
+            model.StructMember("a", "u8", bound="num_of_a"),
+            model.StructMember("b", "u8", bound="num_of_b")
         ]),
     ]
 
@@ -477,11 +506,12 @@ def test_partition_many_arrays_mixed():
     assert [x.name for x in main] == ["num_of_a", "num_of_b", "a"]
     assert [[x.name for x in part] for part in parts] == [["b"]]
 
+
 def test_partition_dynamic_struct():
     nodes = [
         model.Struct("Dynamic", [
             model.StructMember("num_of_a", "u8"),
-            model.StructMember("a", "u8", bound = "num_of_a")
+            model.StructMember("a", "u8", bound="num_of_a")
         ]),
         model.Struct("X", [
             model.StructMember("a", "u8"),
@@ -497,11 +527,12 @@ def test_partition_dynamic_struct():
     assert [x.name for x in main] == ["a", "b"]
     assert [[x.name for x in part] for part in parts] == [["c"]]
 
+
 def test_partition_many_dynamic_structs():
     nodes = [
         model.Struct("Dynamic", [
             model.StructMember("num_of_a", "u8"),
-            model.StructMember("a", "u8", bound = "num_of_a")
+            model.StructMember("a", "u8", bound="num_of_a")
         ]),
         model.Struct("X", [
             model.StructMember("a", "Dynamic"),
@@ -517,16 +548,19 @@ def test_partition_many_dynamic_structs():
     assert [x.name for x in main] == ["a"]
     assert [[x.name for x in part] for part in parts] == [["b"], ["c"]]
 
+
 def process(nodes, warn=None):
     model.cross_reference(nodes)
     model.evaluate_kinds(nodes)
     model.evaluate_sizes(nodes, **(warn and {'warn': warn} or {}))
     return nodes
 
+
 def process_with_warnings(nodes):
     warnings = []
     process(nodes, lambda warning: warnings.append(warning))
     return nodes, warnings
+
 
 def get_size_alignment_padding(node):
     return (
@@ -535,8 +569,10 @@ def get_size_alignment_padding(node):
         (node.byte_size, node.alignment)
     )
 
+
 def get_members_and_node(node):
     return node.members + [node]
+
 
 def test_evaluate_sizes_struct():
     nodes = process([
@@ -550,6 +586,7 @@ def test_evaluate_sizes_struct():
         (1, 1, 1),
         (4, 2)
     ]
+
 
 def test_evaluate_sizes_nested_struct():
     nodes = process([
@@ -567,11 +604,12 @@ def test_evaluate_sizes_nested_struct():
         (4, 2)
     ]
 
+
 def test_evaluate_sizes_fixed_array():
     nodes = process([
         model.Struct('X', [
             model.StructMember('x', 'u32'),
-            model.StructMember('y', 'u8', size = '3')
+            model.StructMember('y', 'u8', size='3')
         ])
     ])
     assert list(map(get_size_alignment_padding, get_members_and_node(nodes[0]))) == [
@@ -580,11 +618,12 @@ def test_evaluate_sizes_fixed_array():
         (8, 4)
     ]
 
+
 def test_evaluate_sizes_dynamic_array():
     nodes = process([
         model.Struct('X', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', bound = 'num_of_x'),
+            model.StructMember('x', 'u8', bound='num_of_x'),
         ]),
         model.Struct('Y', [
             model.StructMember('x', 'u8'),
@@ -613,11 +652,12 @@ def test_evaluate_sizes_dynamic_array():
         (16, 8)
     ]
 
+
 def test_evaluate_sizes_limited_array():
     nodes = process([
         model.Struct('X', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', bound = 'num_of_x', size = '2'),
+            model.StructMember('x', 'u8', bound='num_of_x', size='2'),
         ])
     ])
     assert list(map(get_size_alignment_padding, get_members_and_node(nodes[0]))) == [
@@ -626,11 +666,12 @@ def test_evaluate_sizes_limited_array():
         (8, 4)
     ]
 
+
 def test_evaluate_sizes_greedy_array():
     nodes = process([
         model.Struct('X', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', unlimited = True),
+            model.StructMember('x', 'u8', unlimited=True),
         ])
     ])
     assert list(map(get_size_alignment_padding, get_members_and_node(nodes[0]))) == [
@@ -639,23 +680,24 @@ def test_evaluate_sizes_greedy_array():
         (4, 4)
     ]
 
+
 def test_evaluate_sizes_partial_padding():
     nodes = process([
         model.Struct('D', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u32', bound = 'num_of_x')
+            model.StructMember('x', 'u32', bound='num_of_x')
         ]),
         model.Struct('X', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', bound = 'num_of_x'),
+            model.StructMember('x', 'u8', bound='num_of_x'),
             model.StructMember('y', 'u8'),
             model.StructMember('z', 'u64'),
         ]),
         model.Struct('Y', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u8', bound = 'num_of_x'),
+            model.StructMember('x', 'u8', bound='num_of_x'),
             model.StructMember('num_of_y', 'u32'),
-            model.StructMember('y', 'u64', bound = 'num_of_y'),
+            model.StructMember('y', 'u64', bound='num_of_y'),
         ]),
         model.Struct('Z', [
             model.StructMember('d1', 'D'),
@@ -670,7 +712,7 @@ def test_evaluate_sizes_partial_padding():
         ]),
         model.Struct('ZZZ', [
             model.StructMember('num_of_x', 'u32'),
-            model.StructMember('x', 'u16', bound = 'num_of_x'),
+            model.StructMember('x', 'u16', bound='num_of_x'),
             model.StructMember('y', 'u16'),
         ]),
     ])
@@ -708,6 +750,7 @@ def test_evaluate_sizes_partial_padding():
         (8, 4)
     ]
 
+
 def test_evaluate_sizes_typedef():
     nodes = process([
         model.Typedef('T1', 'u32'),
@@ -728,6 +771,7 @@ def test_evaluate_sizes_typedef():
         (4, 4)
     ]
 
+
 def test_evaluate_sizes_enum():
     nodes = process([
         model.Enum('E', [
@@ -744,6 +788,7 @@ def test_evaluate_sizes_enum():
         (8, 4)
     ]
 
+
 def test_evaluate_sizes_floats():
     nodes = process([
         model.Struct('X', [
@@ -757,13 +802,14 @@ def test_evaluate_sizes_floats():
         (16, 8)
     ]
 
+
 def test_evaluate_sizes_bytes():
     nodes = process([
         model.Struct('X', [
             model.StructMember('x', 'byte'),
-            model.StructMember('y', 'byte', size = 3),
+            model.StructMember('y', 'byte', size=3),
             model.StructMember('num_of_z', 'u32'),
-            model.StructMember('z', 'byte', bound = 'num_of_z')
+            model.StructMember('z', 'byte', bound='num_of_z')
         ])
     ])
     assert list(map(get_size_alignment_padding, get_members_and_node(nodes[0]))) == [
@@ -774,19 +820,20 @@ def test_evaluate_sizes_bytes():
         (8, 4)
     ]
 
+
 def test_evaluate_sizes_optional():
     nodes = process([
         model.Struct('X', [
             model.StructMember('x', 'u32')
         ]),
         model.Struct('O1', [
-            model.StructMember('x', 'u8', optional = True),
-            model.StructMember('y', 'u16', optional = True),
-            model.StructMember('z', 'u32', optional = True),
-            model.StructMember('a', 'u64', optional = True)
+            model.StructMember('x', 'u8', optional=True),
+            model.StructMember('y', 'u16', optional=True),
+            model.StructMember('z', 'u32', optional=True),
+            model.StructMember('a', 'u64', optional=True)
         ]),
         model.Struct('O2', [
-            model.StructMember('x', 'X', optional = True)
+            model.StructMember('x', 'X', optional=True)
         ])
     ])
     assert list(map(get_size_alignment_padding, get_members_and_node(nodes[1]))) == [
@@ -800,6 +847,7 @@ def test_evaluate_sizes_optional():
         (8, 4, 0),
         (8, 4)
     ]
+
 
 def test_evaluate_sizes_union():
     nodes = process([
@@ -832,6 +880,7 @@ def test_evaluate_sizes_union():
         (24, 8)
     ]
 
+
 def test_evaluate_sizes_union_with_padding():
     nodes = process([
         model.Union('X', [
@@ -852,6 +901,7 @@ def test_evaluate_sizes_union_with_padding():
         (16, 8)
     ]
 
+
 def test_evaluate_sizes_empty():
     nodes = process([
         model.Struct('X', []),
@@ -863,6 +913,7 @@ def test_evaluate_sizes_empty():
     assert list(map(get_size_alignment_padding, get_members_and_node(nodes[1]))) == [
         (4, 4)
     ]
+
 
 def test_evaluate_sizes_unknown():
     nodes, warnings = process_with_warnings([
@@ -908,6 +959,7 @@ def test_evaluate_sizes_unknown():
         (None, None)
     ]
 
+
 def test_evaluate_sizes_array_with_named_size():
     nodes = process([
         model.Constant('NUM', '3'),
@@ -916,12 +968,12 @@ def test_evaluate_sizes_array_with_named_size():
             model.EnumMember('E3', 'NUM')
         ]),
         model.Struct('X', [
-            model.StructMember('x', 'u32', size = 'NUM'),
-            model.StructMember('y', 'u32', size = 'E1'),
-            model.StructMember('z', 'u32', size = 'E3')
+            model.StructMember('x', 'u32', size='NUM'),
+            model.StructMember('y', 'u32', size='E1'),
+            model.StructMember('z', 'u32', size='E3')
         ]),
         model.Struct('Y', [
-            model.StructMember('x', 'u32', size = 'UNKNOWN'),
+            model.StructMember('x', 'u32', size='UNKNOWN'),
             model.StructMember('y', 'u32')
         ])
 
@@ -938,6 +990,7 @@ def test_evaluate_sizes_array_with_named_size():
         (4, 4, None),
         (None, None)
     ]
+
 
 def test_evaluate_sizes_with_include():
     nodes = process([
@@ -956,6 +1009,7 @@ def test_evaluate_sizes_with_include():
         (1, 1, 3),
         (8, 4)
     ]
+
 
 def test_enum_repr():
     E = model.Enum('TheEnum', [

--- a/prophyc/tests/test_patch.py
+++ b/prophyc/tests/test_patch.py
@@ -5,14 +5,16 @@ import pytest
 from prophyc import patch
 from prophyc import model
 
+
 def parse(content):
     try:
-        with tempfile.NamedTemporaryFile(delete = False) as temp:
+        with tempfile.NamedTemporaryFile(delete=False) as temp:
             temp.write(content)
             temp.flush()
             return patch.parse(temp.name)
     finally:
         os.unlink(temp.name)
+
 
 def test_parsing_ignoring_empty_lines():
     content = b"""\
@@ -30,6 +32,7 @@ YourStruct type lastField AnotherRealMember
             'YourStruct': [('type', ['firstField', 'YourRealMember']),
                            ('type', ['lastField', 'AnotherRealMember'])]} == patches
 
+
 def test_unknown_action():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
                                        model.StructMember("field2", "u32"),
@@ -39,6 +42,7 @@ def test_unknown_action():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert "Unknown action: MyStruct Action(action='typo_or_something', params=[])" == str(e.value)
+
 
 def test_change_field_type():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -52,13 +56,16 @@ def test_change_field_type():
                                       model.StructMember('field2', 'TheRealType'),
                                       model.StructMember('field3', 'u32')])] == nodes
 
+
 def test_change_field_type_not_a_struct():
     nodes = [model.Typedef("MyStruct", "MyRealStruct")]
     patches = {'MyStruct': [patch.Action('type', ['field2', 'TheRealType'])]}
 
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
-    assert "Can change field only in struct: MyStruct Action(action='type', params=['field2', 'TheRealType'])" == str(e.value)
+    assert "Can change field only in struct: MyStruct Action(action='type', params=['field2', 'TheRealType'])" == str(
+        e.value)
+
 
 def test_change_field_type_no_2_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -75,6 +82,7 @@ def test_change_field_type_no_2_params():
         patch.patch(nodes, patches)
     assert 'Change field must have 2 params: MyStruct' in str(e.value)
 
+
 def test_change_field_type_member_not_found():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
                                        model.StructMember("field2", "u32"),
@@ -84,6 +92,7 @@ def test_change_field_type_member_not_found():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert 'Member not found: MyStruct' in str(e.value)
+
 
 def test_insert_field():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -102,6 +111,7 @@ def test_insert_field():
                                       model.StructMember('field3', 'u32'),
                                       model.StructMember('additional3', 'u64')])] == nodes
 
+
 def test_insert_field_not_a_struct():
     nodes = [model.Typedef("MyStruct", "MyRealStruct")]
     patches = {'MyStruct': [patch.Action('insert', ['1', 'additional1', 'u8'])]}
@@ -109,6 +119,7 @@ def test_insert_field_not_a_struct():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert 'Can insert field only in struct: MyStruct' in str(e.value)
+
 
 def test_insert_field_no_3_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32")])]
@@ -118,6 +129,7 @@ def test_insert_field_no_3_params():
         patch.patch(nodes, patches)
     assert 'Change field must have 3 params: MyStruct' in str(e.value)
 
+
 def test_insert_field_index_not_an_int():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32")])]
     patches = {'MyStruct': [patch.Action('insert', ['not_a_number', 'additional1', 'u8'])]}
@@ -125,6 +137,7 @@ def test_insert_field_index_not_an_int():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert 'Index is not a number: MyStruct' in str(e.value)
+
 
 def test_remove_field():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -137,6 +150,7 @@ def test_remove_field():
     assert [model.Struct('MyStruct', [model.StructMember('field1', 'u32'),
                                       model.StructMember('field3', 'u32')])] == nodes
 
+
 def test_remove_field_not_a_struct():
     nodes = [model.Typedef("MyStruct", "MyRealStruct")]
     patches = {'MyStruct': [patch.Action('remove', ['field2'])]}
@@ -144,6 +158,7 @@ def test_remove_field_not_a_struct():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert 'Can remove field only in struct: MyStruct' in str(e.value)
+
 
 def test_remove_field_no_1_param():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32")])]
@@ -153,6 +168,7 @@ def test_remove_field_no_1_param():
         patch.patch(nodes, patches)
     assert 'Remove field must have 1 param: MyStruct' in str(e.value)
 
+
 def test_remove_field_not_found():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32")])]
     patches = {'MyStruct': [patch.Action('remove', ['not_a_field'])]}
@@ -160,6 +176,7 @@ def test_remove_field_not_found():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert 'Member not found: MyStruct' in str(e.value)
+
 
 def test_make_field_dynamic_array():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -171,7 +188,8 @@ def test_make_field_dynamic_array():
 
     assert [model.Struct('MyStruct', [model.StructMember('field1', 'u32'),
                                       model.StructMember('field2', 'u32'),
-                                      model.StructMember('field3', 'u32', bound = 'field1')])] == nodes
+                                      model.StructMember('field3', 'u32', bound='field1')])] == nodes
+
 
 def test_make_field_dynamic_array_not_a_struct():
     nodes = [model.Typedef("MyStruct", "MyRealStruct")]
@@ -180,6 +198,7 @@ def test_make_field_dynamic_array_not_a_struct():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert "Can change field only in struct: MyStruct" in str(e.value)
+
 
 def test_make_field_dynamic_array_no_2_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -196,6 +215,7 @@ def test_make_field_dynamic_array_no_2_params():
         patch.patch(nodes, patches)
     assert 'Change field must have 2 params: MyStruct' in str(e.value)
 
+
 def test_make_field_dynamic_array_member_not_found():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
                                        model.StructMember("field2", "u32"),
@@ -205,6 +225,7 @@ def test_make_field_dynamic_array_member_not_found():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert 'Member not found: MyStruct' in str(e.value)
+
 
 def test_make_field_greedy_array():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -216,7 +237,8 @@ def test_make_field_greedy_array():
 
     assert [model.Struct('MyStruct', [model.StructMember('field1', 'u32'),
                                       model.StructMember('field2', 'u32'),
-                                      model.StructMember('field3', 'u32', unlimited = True)])] == nodes
+                                      model.StructMember('field3', 'u32', unlimited=True)])] == nodes
+
 
 def test_make_field_greedy_array_not_a_struct():
     nodes = [model.Typedef("MyStruct", "MyRealStruct")]
@@ -225,6 +247,7 @@ def test_make_field_greedy_array_not_a_struct():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert "Can change field only in struct: MyStruct" in str(e.value)
+
 
 def test_make_field_greedy_array_no_1_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -247,6 +270,7 @@ def test_make_field_greedy_array_with_wrong_name_params():
         patch.patch(nodes, patches)
     assert 'Member not found: MyStruct' in str(e.value)
 
+
 def test_make_field_static_array():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
                                        model.StructMember("field2", "u32"),
@@ -257,7 +281,8 @@ def test_make_field_static_array():
 
     assert [model.Struct('MyStruct', [model.StructMember('field1', 'u32'),
                                       model.StructMember('field2', 'u32'),
-                                      model.StructMember('field3', 'u32', size = '3')])] == nodes
+                                      model.StructMember('field3', 'u32', size='3')])] == nodes
+
 
 def test_make_field_static_array_not_a_struct():
     nodes = [model.Typedef("MyStruct", "MyRealStruct")]
@@ -266,6 +291,7 @@ def test_make_field_static_array_not_a_struct():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert "Can change field only in struct: MyStruct" in str(e.value)
+
 
 def test_make_field_static_array_no_2_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -282,6 +308,7 @@ def test_make_field_static_array_no_2_params():
         patch.patch(nodes, patches)
     assert 'Change field must have 2 params: MyStruct' in str(e.value)
 
+
 def test_make_field_static_array_with_wrong_name_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
                                        model.StructMember("field2", "u32"),
@@ -292,17 +319,19 @@ def test_make_field_static_array_with_wrong_name_params():
         patch.patch(nodes, patches)
     assert 'Member not found: MyStruct' in str(e.value)
 
+
 def test_make_field_limited_array():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
                                        model.StructMember("field2", "u32"),
-                                       model.StructMember("field3", "u32", size = '20')])]
+                                       model.StructMember("field3", "u32", size='20')])]
     patches = {'MyStruct': [patch.Action('limited', ['field3', 'field2'])]}
 
     patch.patch(nodes, patches)
 
     assert [model.Struct('MyStruct', [model.StructMember('field1', 'u32'),
                                       model.StructMember('field2', 'u32'),
-                                      model.StructMember('field3', 'u32', bound = 'field2', size = '20')])] == nodes
+                                      model.StructMember('field3', 'u32', bound='field2', size='20')])] == nodes
+
 
 def test_make_field_limited_array_not_a_struct():
     nodes = [model.Typedef("MyStruct", "MyRealStruct")]
@@ -311,6 +340,7 @@ def test_make_field_limited_array_not_a_struct():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert "Can change field only in struct: MyStruct" in str(e.value)
+
 
 def test_make_field_limited_array_no_2_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -327,6 +357,7 @@ def test_make_field_limited_array_no_2_params():
         patch.patch(nodes, patches)
     assert 'Change field must have 2 params: MyStruct' in str(e.value)
 
+
 def test_make_field_limited_array_with_wrong_name_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
                                        model.StructMember("field2", "u32"),
@@ -336,6 +367,7 @@ def test_make_field_limited_array_with_wrong_name_params():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert 'Member not found: MyStruct' in str(e.value)
+
 
 def test_make_field_limited_array_with_wrong_bound_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -347,6 +379,7 @@ def test_make_field_limited_array_with_wrong_bound_params():
         patch.patch(nodes, patches)
     assert 'Array len member not found: MyStruct' in str(e.value)
 
+
 def test_change_union_to_struct():
     nodes = [model.Union("MyUnion", [model.UnionMember("field1", "u32", 1)])]
     patches = {'MyUnion': [patch.Action('struct', [])]}
@@ -354,6 +387,7 @@ def test_change_union_to_struct():
     patch.patch(nodes, patches)
 
     assert [model.Struct('MyUnion', [model.StructMember('field1', 'u32')])] == nodes
+
 
 def test_change_union_to_struct_and_remove_field():
     nodes = [model.Union("MyUnion", [model.UnionMember("field1", "u32", 1),
@@ -368,6 +402,7 @@ def test_change_union_to_struct_and_remove_field():
     assert [model.Struct('MyUnion', [model.StructMember('field1', 'u32'),
                                      model.StructMember('field3', 'u32')])] == nodes
 
+
 def test_change_union_to_struct_not_a_union():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32", 1),
                                        model.StructMember("field2", "u32", 2)])]
@@ -377,6 +412,7 @@ def test_change_union_to_struct_not_a_union():
         patch.patch(nodes, patches)
     assert 'Can only change union to struct: MyStruct' in str(e.value)
 
+
 def test_change_union_to_struct_excessive_params():
     nodes = [model.Union("MyUnion", [model.UnionMember("field1", "u32", 1),
                                      model.UnionMember("field2", "u32", 2)])]
@@ -385,6 +421,7 @@ def test_change_union_to_struct_excessive_params():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert 'Change union to struct takes no params: MyUnion' in str(e.value)
+
 
 def test_rename_node():
     nodes = [model.Struct("OldStruct", [model.StructMember("field", "u32")]),
@@ -397,6 +434,7 @@ def test_rename_node():
 
     assert nodes[0].name == 'NewStruct'
     assert nodes[1].name == 'NewEnum'
+
 
 def test_rename_field():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32"),
@@ -411,6 +449,7 @@ def test_rename_field():
                                       model.StructMember('field69', 'u32'),
                                       model.StructMember('field3', 'u32')])] == nodes
 
+
 def test_rename_field_not_composite():
     nodes = [model.Enum("MyEnum", [model.EnumMember("val", "123")])]
 
@@ -420,6 +459,7 @@ def test_rename_field_not_composite():
         patch.patch(nodes, patches)
     assert 'Can rename fields only in composites: MyEnum' in str(e.value)
 
+
 def test_rename_field_member_not_found():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32")])]
 
@@ -428,6 +468,7 @@ def test_rename_field_member_not_found():
     with pytest.raises(Exception) as e:
         patch.patch(nodes, patches)
     assert 'Member not found: MyStruct' in str(e.value)
+
 
 def test_rename_field_excessive_params():
     nodes = [model.Struct("MyStruct", [model.StructMember("field1", "u32")])]

--- a/prophyc/tests/test_prophyc.py
+++ b/prophyc/tests/test_prophyc.py
@@ -7,6 +7,7 @@ empty_python_output = """\
 import prophy
 """
 
+
 def test_showing_version(call_prophyc):
     ret, out, err = call_prophyc(["--version"])
     expected_version = '1.1.2'
@@ -14,11 +15,13 @@ def test_showing_version(call_prophyc):
     assert out == 'prophyc %s\n' % expected_version
     assert err == ""
 
+
 def test_missing_input(call_prophyc):
     ret, out, err = call_prophyc([])
     assert ret == 1
     assert out == ""
     assert err == "prophyc: error: missing input file\n"
+
 
 def test_no_output_directory(call_prophyc, dummy_file):
     ret, out, err = call_prophyc(["--python_out", "no_dir", dummy_file])
@@ -26,11 +29,13 @@ def test_no_output_directory(call_prophyc, dummy_file):
     assert out == ""
     assert err == "prophyc: error: argument --python_out: no_dir directory not found\n"
 
+
 def test_no_input_file(call_prophyc):
     ret, out, err = call_prophyc(["path/that/does/not/exist"])
     assert ret == 1
     assert out == ""
     assert err == "prophyc: error: argument INPUT_FILE: path/that/does/not/exist file not found\n"
+
 
 def test_missing_output(call_prophyc, dummy_file):
     ret, out, err = call_prophyc(["--isar", dummy_file])
@@ -38,11 +43,13 @@ def test_missing_output(call_prophyc, dummy_file):
     assert out == ""
     assert err == "prophyc: error: missing output directives\n"
 
+
 def test_passing_isar_and_sack(call_prophyc, dummy_file):
     ret, out, err = call_prophyc(["--isar", "--sack", "--python_out", ".", dummy_file])
     assert ret == 1
     assert out == ""
     assert err == "prophyc: error: argument --sack: not allowed with argument --isar\n"
+
 
 def test_including_isar_with_isar(call_prophyc, dummy_file):
     ret, out, err = call_prophyc(["--isar", "--include_isar", dummy_file, "--python_out", ".",
@@ -50,6 +57,7 @@ def test_including_isar_with_isar(call_prophyc, dummy_file):
     assert ret == 1
     assert out == ""
     assert err == 'prophyc: error: Isar defines inclusion is supported only in "sack" compilation mode.\n'
+
 
 def test_isar_compiles_single_empty_xml(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.xml").write("<struct/>")
@@ -59,6 +67,7 @@ def test_isar_compiles_single_empty_xml(call_prophyc, tmpdir_cwd):
     assert out == ""
     assert err == ""
     assert empty_python_output == tmpdir_cwd.join("input.py").read()
+
 
 def test_isar_compiles_multiple_empty_xmls(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input1.xml").write("<struct/>")
@@ -77,6 +86,7 @@ def test_isar_compiles_multiple_empty_xmls(call_prophyc, tmpdir_cwd):
     assert empty_python_output == tmpdir_cwd.join("input2.py").read()
     assert empty_python_output == tmpdir_cwd.join("input3.py").read()
 
+
 def test_outputs_to_correct_directory(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.xml").write("<struct/>")
     os.mkdir("output")
@@ -87,6 +97,7 @@ def test_outputs_to_correct_directory(call_prophyc, tmpdir_cwd):
     assert out == ""
     assert err == ""
     assert empty_python_output == tmpdir_cwd.join(os.path.join("output", "input.py")).read()
+
 
 def test_isar_patch(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.xml").write("""\
@@ -122,6 +133,7 @@ class B(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
                    ('b', prophy.array(A, bound = 'a'))]
 """ == tmpdir_cwd.join("input.py").read()
 
+
 def test_isar_cpp(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.xml").write("""
 <xml>
@@ -155,6 +167,7 @@ Test* swap<Test>(Test* payload)
 }
 """ in tmpdir_cwd.join("input.pp.cpp").read()
 
+
 def test_isar_warnings(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.xml").write("""
 <xml>
@@ -170,6 +183,7 @@ def test_isar_warnings(call_prophyc, tmpdir_cwd):
     assert ret == 0
     assert out == ""
     assert err == "prophyc: warning: file include.xml not found\n"
+
 
 def test_quiet_warnings(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.xml").write("""
@@ -187,6 +201,7 @@ def test_quiet_warnings(call_prophyc, tmpdir_cwd):
     assert ret == 0
     assert out == ""
     assert err == ""
+
 
 def test_isar_with_includes(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.xml").write("""
@@ -231,6 +246,7 @@ struct X : public prophy::detail::message<X>
 };
 """ in tmpdir_cwd.join("input.ppf.hpp").read()
 
+
 @pytest.clang_installed
 def test_sack_compiles_single_empty_hpp(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.hpp").write("")
@@ -242,6 +258,7 @@ def test_sack_compiles_single_empty_hpp(call_prophyc, tmpdir_cwd):
     assert out == ""
     assert err == ""
     assert empty_python_output == tmpdir_cwd.join("input.py").read()
+
 
 @pytest.clang_installed
 def test_sack_patch(call_prophyc, tmpdir_cwd):
@@ -266,6 +283,7 @@ X type x r64
 class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
     _descriptor = [('x', prophy.r64)]
 """ == tmpdir_cwd.join("input.py").read()
+
 
 @pytest.clang_installed
 def test_multiple_outputs(call_prophyc, tmpdir_cwd):
@@ -330,6 +348,7 @@ Test* swap<Test>(Test* payload)
 } // namespace prophy
 """
 
+
 @pytest.clang_not_installed
 def test_clang_not_installed(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.hpp").write("")
@@ -340,6 +359,7 @@ def test_clang_not_installed(call_prophyc, tmpdir_cwd):
     assert ret == 1
     assert out == ""
     assert err == "prophyc: error: %s\n" % pytest.clang_not_installed.args[0].error
+
 
 def test_prophy_language(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.prophy").write("""\
@@ -448,6 +468,7 @@ U* swap<U>(U* payload)
 } // namespace prophy
 """
 
+
 def test_prophy_parse_errors(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.prophy").write("""\
 struct X {};
@@ -464,6 +485,7 @@ constant
     assert errlines[0].endswith("input.prophy:1:11: error: syntax error at '}'")
     assert errlines[1].endswith("input.prophy:2:10: error: syntax error at '}'")
     assert not os.path.exists("input.py")
+
 
 @pytest.clang_installed
 def test_sack_parse_warnings(call_prophyc, tmpdir_cwd):
@@ -482,6 +504,7 @@ rubbish;
     assert 'input.cpp:2:1: warning: C++ requires a type specifier for all declarations' in errlines[1]
     assert os.path.exists("input.py")
 
+
 @pytest.clang_installed
 def test_sack_parse_errors(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.unknown").write("")
@@ -492,6 +515,7 @@ def test_sack_parse_errors(call_prophyc, tmpdir_cwd):
     assert out == ""
     assert 'input.unknown: error: error parsing translation unit' in err
     assert not os.path.exists("input.py")
+
 
 def test_cpp_full_out(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.prophy").write("""
@@ -610,6 +634,7 @@ template void message_impl<X>::print(const X& x, std::ostream& out, size_t inden
 } // namespace prophy
 """
 
+
 def test_cpp_full_out_error(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.xml").write("""
 <xml>
@@ -630,6 +655,7 @@ prophyc: warning: type 'Unknown' not found
 prophyc: warning: Test::x has unknown type "Unknown"
 prophyc: error: Test byte size unknown
 """
+
 
 def test_model_evaluation_warnings(call_prophyc, tmpdir_cwd):
     tmpdir_cwd.join("input.prophy").write("""

--- a/prophyc/tests/test_prophyc.py
+++ b/prophyc/tests/test_prophyc.py
@@ -126,11 +126,15 @@ B dynamic b a
     assert empty_python_output + """\
 
 class A(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('a', prophy.u8)]
+    _descriptor = [
+        ('a', prophy.u8)
+    ]
 
 class B(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('a', prophy.u8),
-                   ('b', prophy.array(A, bound = 'a'))]
+    _descriptor = [
+        ('a', prophy.u8),
+        ('b', prophy.array(A, bound = 'a'))
+    ]
 """ == tmpdir_cwd.join("input.py").read()
 
 
@@ -281,7 +285,9 @@ X type x r64
     assert empty_python_output + """\
 
 class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('x', prophy.r64)]
+    _descriptor = [
+        ('x', prophy.r64)
+    ]
 """ == tmpdir_cwd.join("input.py").read()
 
 
@@ -306,7 +312,9 @@ def test_multiple_outputs(call_prophyc, tmpdir_cwd):
 import prophy
 
 class Test(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('x', prophy.u32)]
+    _descriptor = [
+        ('x', prophy.u32)
+    ]
 """
     assert tmpdir_cwd.join("input.pp.hpp").read() == """\
 #ifndef _PROPHY_GENERATED_input_HPP
@@ -385,13 +393,17 @@ union U
 import prophy
 
 class X(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('x', prophy.array(prophy.u32, size = 5)),
-                   ('num_of_y', prophy.u32),
-                   ('y', prophy.array(prophy.u64, bound = 'num_of_y', size = 2))]
+    _descriptor = [
+        ('x', prophy.array(prophy.u32, size = 5)),
+        ('num_of_y', prophy.u32),
+        ('y', prophy.array(prophy.u64, bound = 'num_of_y', size = 2))
+    ]
 
 class U(prophy.with_metaclass(prophy.union_generator, prophy.union)):
-    _descriptor = [('x', X, 1),
-                   ('y', prophy.u32, 2)]
+    _descriptor = [
+        ('x', X, 1),
+        ('y', prophy.u32, 2)
+    ]
 """
     assert tmpdir_cwd.join("input.pp.hpp").read() == """\
 #ifndef _PROPHY_GENERATED_input_HPP

--- a/prophyc/tests/test_prophyc_with_prophy.py
+++ b/prophyc/tests/test_prophyc_with_prophy.py
@@ -5,8 +5,10 @@ opd = os.path.dirname
 opr = os.path.realpath
 main_dir = opd(opd(opr(__file__)))
 
+
 def form_args(mode, tmpdir_cwd, target_file_name):
     return [mode, "--python_out", str(tmpdir_cwd), os.path.join(str(tmpdir_cwd), target_file_name)]
+
 
 def test_isar_input(tmpdir_cwd, call_prophyc):
     content = """\
@@ -47,6 +49,7 @@ def test_isar_input(tmpdir_cwd, call_prophyc):
     s.nodeAddr = 0x1231
 
     assert b"\x00\x00\x00\x01\x12\x31\x00\x00" == s.encode(">")
+
 
 @pytest.clang_installed
 def test_sack_input(tmpdir_cwd, call_prophyc):

--- a/prophyc/tests/test_supplementation.py
+++ b/prophyc/tests/test_supplementation.py
@@ -40,10 +40,12 @@ IsarDefA = prophy.r32
 IsarDefB = prophy.r64
 
 class EIsarDefEnum(prophy.with_metaclass(prophy.enum_generator, prophy.enum)):
-    _enumerators  = [('EIsarDefEnum_A', 0),
-                     ('EIsarDefEnum_B', 1),
-                     ('EIsarDefEnum_C', 2),
-                     ('EIsarDefEnum_D', 4)]
+    _enumerators = [
+        ('EIsarDefEnum_A', 0),
+        ('EIsarDefEnum_B', 1),
+        ('EIsarDefEnum_C', 2),
+        ('EIsarDefEnum_D', 4)
+    ]
 
 EIsarDefEnum_A = 0
 EIsarDefEnum_B = 1
@@ -51,9 +53,11 @@ EIsarDefEnum_C = 2
 EIsarDefEnum_D = 4
 
 class IsarDefC(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('ifC_a', prophy.u16),
-                   ('ifC_b_len', prophy.u32),
-                   ('ifC_b', prophy.array(prophy.u64, bound = 'ifC_b_len'))]
+    _descriptor = [
+        ('ifC_a', prophy.u16),
+        ('ifC_b_len', prophy.u32),
+        ('ifC_b', prophy.array(prophy.u64, bound = 'ifC_b_len'))
+    ]
 """),
 
 
@@ -81,12 +85,16 @@ import prophy
 from isar_root_defs import *
 
 class IsarK(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('ifK_a', prophy.u8),
-                   ('ifK_B', prophy.array(IsarDefB, size = IsarCONST_A))]
+    _descriptor = [
+        ('ifK_a', prophy.u8),
+        ('ifK_B', prophy.array(IsarDefB, size = IsarCONST_A))
+    ]
 
 class IsarL(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('numOfItems', prophy.u32),
-                   ('theBItems', prophy.array(IsarDefB, bound = 'numOfItems'))]
+    _descriptor = [
+        ('numOfItems', prophy.u32),
+        ('theBItems', prophy.array(IsarDefB, bound = 'numOfItems'))
+    ]
 """),
 
     IsarTestItem(
@@ -109,10 +117,12 @@ import prophy
 from isar_root_defs import *
 
 class IsarV(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('ifV_a', IsarDefA),
-                   ('ifV_b_len', prophy.u32),
-                   ('ifV_b', prophy.array(IsarDefB, bound = 'ifV_b_len', size = IsarCONST_B)),
-                   ('ifV_c', EIsarDefEnum)]
+    _descriptor = [
+        ('ifV_a', IsarDefA),
+        ('ifV_b_len', prophy.u32),
+        ('ifV_b', prophy.array(IsarDefB, bound = 'ifV_b_len', size = IsarCONST_B)),
+        ('ifV_c', EIsarDefEnum)
+    ]
 """)
 ]
 
@@ -163,10 +173,12 @@ from included_by_sack_a import *
 from included_by_sack_b import *
 
 class cppX(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('defined_in_xml', IsarK),
-                   ('defined_deeper_in_xmls', IsarDefC),
-                   ('regular_type', prophy.u16),
-                   ('typedefed_deeper_in_xmls', IsarDefA)]
+    _descriptor = [
+        ('defined_in_xml', IsarK),
+        ('defined_deeper_in_xmls', IsarDefC),
+        ('regular_type', prophy.u16),
+        ('typedefed_deeper_in_xmls', IsarDefA)
+    ]
 """
 
 
@@ -197,8 +209,10 @@ from included_by_sack_a import *
 from included_by_sack_b import *
 
 class cppX(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('type_from_isar', prophy.array(IsarV, size = 4)),
-                   ('regular_type', prophy.array(prophy.u16, size = 16))]
+    _descriptor = [
+        ('type_from_isar', prophy.array(IsarV, size = 4)),
+        ('regular_type', prophy.array(prophy.u16, size = 16))
+    ]
 """
 
 
@@ -242,10 +256,12 @@ class constants(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
     _descriptor = []
 
 class cppX(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
-    _descriptor = [('straigth', prophy.array(prophy.u8, size = 2)),
-                   ('tricky1', prophy.array(prophy.u16, size = 4)),
-                   ('tricky2', prophy.array(prophy.u16, size = 20)),
-                   ('tricky3', prophy.array(prophy.u16, size = 64))]
+    _descriptor = [
+        ('straigth', prophy.array(prophy.u8, size = 2)),
+        ('tricky1', prophy.array(prophy.u16, size = 4)),
+        ('tricky2', prophy.array(prophy.u16, size = 20)),
+        ('tricky3', prophy.array(prophy.u16, size = 64))
+    ]
 """
 
 

--- a/prophyc/tests/test_supplementation.py
+++ b/prophyc/tests/test_supplementation.py
@@ -248,6 +248,7 @@ class cppX(prophy.with_metaclass(prophy.struct_generator, prophy.struct)):
                    ('tricky3', prophy.array(prophy.u16, size = 64))]
 """
 
+
 @pytest.clang_installed
 def test_warns_with_supplementation(isar_test_helper, tmpdir_cwd, call_prophyc):
     cpp = tmpdir_cwd.join('the_sack.hpp')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,7 @@
 [flake8]
 builtins = long, xrange
+max-line-length = 120
 exclude = prophyc/parsers/clang, prophyc/six.py
-ignore = E251, E302, E305, E501, E701
-    # E251 unexpected spaces around keyword / parameter equals
-    # E302 expected 2 blank lines, found 1
-    # E305 expected 2 blank lines after class or function definition, found 1
-    # E501 line too long
-    # E701 multiple statements on one line (colon)
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup, find_packages
 
+# flake8: noqa
+
 long_description = open('README.rst').read()
 
 setup(


### PR DESCRIPTION
The code style has been conformed to [PEP8](https://www.python.org/dev/peps/pep-0008/).
List of ignored style errors in `flake8` config has been removed. Remaining minor exclusions of style violations got marked with `noqa` in the given sources (mostly E501, exceeded line length in two source files).

The code got aligned to the most popular, generic [`autopep8.py` auto-formatter](https://github.com/hhatto/autopep8) so that running the formatter on the source code (with first level of aggressiveness) will not change it at all.

The style standard has been applied to both: source code and code generated by `python generator`.

No `functional` change to any python code has been introduced at all (besides slightly different whitespaces in the generated python code).