### PR TITLE
Add specialized exception for decoding errors

### DIFF
--- a/prophy/__init__.py
+++ b/prophy/__init__.py
@@ -11,7 +11,7 @@ from .composite import (struct,
                         union,
                         union_generator)
 
-from .exception import ProphyError
+from .exception import CONSTRAINT_VIOLATION, DecodeError, NOT_ENOUGH_BYTES, ProphyError, TOO_MANY_BYTES
 from .six import with_metaclass
 from .kind import kind
 
@@ -28,7 +28,7 @@ __all__ = [
     'struct_generator',
     'union',
     'union_generator',
-    'ProphyError',
+    'CONSTRAINT_VIOLATION', 'DecodeError', 'NOT_ENOUGH_BYTES', 'ProphyError', 'TOO_MANY_BYTES',
     'with_metaclass',
     'kind',
 ]

--- a/prophy/container.py
+++ b/prophy/container.py
@@ -1,5 +1,5 @@
 from . import composite
-from .exception import ProphyError
+from .exception import DecodeError, NOT_ENOUGH_BYTES, ProphyError
 from .base_array import base_array
 from .six import xrange
 
@@ -120,7 +120,7 @@ class bound_scalar_array(base_array):
 
     def _decode_impl(self, data, pos, endianness, len_hint):
         if self._SIZE > (len(data) - pos):
-            raise ProphyError("too few bytes to decode array")
+            raise DecodeError("too few bytes to decode array", NOT_ENOUGH_BYTES)
         self[:], size = decode_scalar_array(self._TYPE, data, pos, endianness, len_hint)
         return max(size, self._SIZE)
 
@@ -190,7 +190,7 @@ class bound_composite_array(base_array):
 
     def _decode_impl(self, data, pos, endianness, len_hint):
         if self._SIZE > (len(data) - pos):
-            raise ProphyError("too few bytes to decode array")
+            raise DecodeError("too few bytes to decode array", NOT_ENOUGH_BYTES)
         del self[:]
         cursor = 0
         if not self._SIZE and not self._BOUND:

--- a/prophy/exception.py
+++ b/prophy/exception.py
@@ -1,2 +1,11 @@
+CONSTRAINT_VIOLATION, TOO_MANY_BYTES, NOT_ENOUGH_BYTES = range(3)
+
+
 class ProphyError(Exception):
     pass
+
+
+class DecodeError(ProphyError):
+    def __init__(self, message, subtype=None):
+        super(DecodeError, self).__init__(message)
+        self.subtype = subtype

--- a/prophy/scalar.py
+++ b/prophy/scalar.py
@@ -1,5 +1,6 @@
 import struct
-from .exception import ProphyError
+
+from .exception import DecodeError, NOT_ENOUGH_BYTES, ProphyError
 from .six import long
 
 
@@ -11,7 +12,7 @@ def numeric_decorator(cls, size, id_):
     @staticmethod
     def decode(data, pos, endianness):
         if (len(data) - pos) < size:
-            raise ProphyError("too few bytes to decode integer")
+            raise DecodeError("too few bytes to decode integer", NOT_ENOUGH_BYTES)
         value, = struct.unpack(endianness + id_, data[pos:(pos + size)])
         return value, size
 
@@ -209,14 +210,14 @@ def bytes_(**kwargs):
         @staticmethod
         def _decode(data, pos, len_hint):
             if (len(data) - pos) < size:
-                raise ProphyError("too few bytes to decode string")
+                raise DecodeError("too few bytes to decode string", NOT_ENOUGH_BYTES)
             if size and not bound:
                 return data[pos:(pos + size)], size
             elif size and bound:
                 return data[pos:(pos + len_hint)], size
             elif bound:
                 if (len(data) - pos) < len_hint:
-                    raise ProphyError("too few bytes to decode string")
+                    raise DecodeError("too few bytes to decode string", NOT_ENOUGH_BYTES)
                 return data[pos:(pos + len_hint)], len_hint
             else:  # greedy
                 return data[pos:], (len(data) - pos)

--- a/prophy/tests/test_array_ext_sized.py
+++ b/prophy/tests/test_array_ext_sized.py
@@ -125,13 +125,15 @@ def test_ext_sized_scalar_array_with_shift_exceptions():
 
 def test_ext_sized_scalar_array_decoding_exceptions(ExtSizedArr):
     x = ExtSizedArr()
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x10\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00", ">")
     assert 'too few bytes to decode integer' in str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x01\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x02\x00", ">")
     assert 'not all bytes of ExtSizedArr read' in str(e.value)
+    assert e.value.subtype == prophy.TOO_MANY_BYTES
 
 
 def test_multiple_arrays_size_mismatch_during_encoding(ExtSizedArr):

--- a/prophy/tests/test_array_fixed.py
+++ b/prophy/tests/test_array_fixed.py
@@ -196,9 +196,10 @@ def test_fixed_array_decode_exception():
         _descriptor = [("a_len", prophy.u8),
                        ("a", prophy.array(prophy.u8, bound="a_len", size=3))]
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         A().decode(b"\x00", ">")
     assert "A: too few bytes to decode array" == str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
 
 def test_fixed_array_decode_size_over_255():

--- a/prophy/tests/test_array_greedy.py
+++ b/prophy/tests/test_array_greedy.py
@@ -75,8 +75,9 @@ def test_greedy_scalar_array_decode(GreedyScalarArray):
     a.decode(b"\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x04", ">")
     assert a.x[:] == [1, 2, 3, 4]
 
-    with pytest.raises(prophy.ProphyError):
+    with pytest.raises(prophy.DecodeError) as e:
         a.decode(b"\x00\x00\x00\x0a\x00\x00\x00\x04\x00", ">")
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
 
 def test_greedy_composite_array_assignment(GreedyCompositeArray, Composite):
@@ -162,8 +163,9 @@ def test_greedy_composite_array_decode(GreedyCompositeArray):
     assert a.x[2].x == 1
     assert a.x[2].y == -1
 
-    with pytest.raises(Exception):
+    with pytest.raises(prophy.DecodeError) as e:
         a.decode(b"\x00\x0a\x00\x14\x00\x0a\x00\x14\x00\x01\xff\xff\x00", ">")
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
 
 def test_greedy_complex_composite_array_assignment(GreedyComplexCompositeArray):
@@ -296,9 +298,10 @@ def test_greedy_complex_composite_array_decode(GreedyComplexCompositeArray):
     assert a.x[1].x.x == 7
     assert a.x[1].x.y == 8
 
-    with pytest.raises(Exception):
+    with pytest.raises(prophy.DecodeError) as e:
         a.decode(b"\x00\x00\x00\x02\x00\x01\x00\x02\x00\x03\x00\x04"
                  b"\x00\x05\x00\x06\x00\x00\x00\x00\x00\x07\x00\x08\x00", ">")
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
 
 def test_greedy_array_exceptions():

--- a/prophy/tests/test_array_limited.py
+++ b/prophy/tests/test_array_limited.py
@@ -76,21 +76,25 @@ def test_limited_scalar_array_decode(LimitedScalarArray):
     a.decode(b"\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x00", ">")
     assert a.value[:] == [1, 2]
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         a.decode(b"\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01", ">")
     assert 'exceeded array limit' in str(e.value)
+    assert e.value.subtype == prophy.CONSTRAINT_VIOLATION
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         a.decode(b"\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00", ">")
     assert 'too few bytes to decode array' in str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         a.decode(b"\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00", ">")
     assert 'not all bytes of LimitedScalarArray read' in str(e.value)
+    assert e.value.subtype == prophy.TOO_MANY_BYTES
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         a.decode(b"\x00\x00\x00\x00", ">")
     assert 'too few bytes to decode array' in str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
 
 def test_limited_composite_array_assigment(LimitedCompositeArray, Composite):
@@ -145,25 +149,28 @@ def test_limited_composite_array_exception(LimitedCompositeArray, Composite):
         a.value.add()
     assert "exceeded array limit" == str(e.value)
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         a.decode((b"\x00\x00\x00\x04"
                   b"\x00\x00\x00\x22\x00\x00\x00\x13"
                   b"\x00\x00\x00\x22\x00\x00\x00\x13"
                   b"\x00\x00\x00\x22\x00\x00\x00\x13"
                   b"\x00\x00\x00\x33\x00\x00\x00\x14"), ">")
     assert "LimitedCompositeArray: exceeded array limit" == str(e.value)
+    assert e.value.subtype == prophy.CONSTRAINT_VIOLATION
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         a.decode((b"\x00\x00\x00\x03"
                   b"\x00\x00\x00\x22\x00\x00\x00\x13"
                   b"\x00\x00\x00\x22\x00\x00\x00\x13"
                   b"\x00\x00\x00\x22\x00\x00\x00\x13"
                   b"\x00"), ">")
     assert "not all bytes of LimitedCompositeArray read" == str(e.value)
+    assert e.value.subtype == prophy.TOO_MANY_BYTES
 
-    with pytest.raises(prophy.ProphyError) as e:
-        a.decode((b"\x00\x00\x00\x00"), ">")
+    with pytest.raises(prophy.DecodeError) as e:
+        a.decode(b"\x00\x00\x00\x00", ">")
     assert "LimitedCompositeArray: too few bytes to decode array" == str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
 
 def test_limited_composite_array_encode(LimitedCompositeArray, Composite):

--- a/prophy/tests/test_bytes.py
+++ b/prophy/tests/test_bytes.py
@@ -95,11 +95,13 @@ def test_fixed_bytes_encoding(FixedBytes):
     x.decode(b"abc\x00\x00", ">")
     assert x.value == b"abc\x00\x00"
 
-    with pytest.raises(Exception):
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x01\x00\x00\x00\x00\x00", ">")
+    assert e.value.subtype == prophy.TOO_MANY_BYTES
 
-    with pytest.raises(Exception):
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x01\x00\x00\x00", ">")
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
 
 def test_fixed_bytes_twice_in_struct():
@@ -211,17 +213,20 @@ def test_shift_bound_bytes_encoding(ShiftBoundBytes):
 def test_shift_bound_bytes_encoding_exceptions(ShiftBoundBytes):
     x = ShiftBoundBytes()
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x01", ">")
     assert str(e.value) == "ShiftBoundBytes: decoded array length smaller than shift"
+    assert e.value.subtype == prophy.CONSTRAINT_VIOLATION
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x05", ">")
     assert str(e.value) == "ShiftBoundBytes: too few bytes to decode string"
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x02\x00", ">")
     assert str(e.value) == "not all bytes of ShiftBoundBytes read"
+    assert e.value.subtype == prophy.TOO_MANY_BYTES
 
 
 @pytest.mark.parametrize('bytes_type', [

--- a/prophy/tests/test_enum.py
+++ b/prophy/tests/test_enum.py
@@ -82,17 +82,20 @@ def test_enum_encoding(Enum):
     x.decode(b"\x00\x00\x00\x03", ">")
     assert x.value == 3
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x00\x00\x00\x09", ">")
     assert 'unknown enumerator Enumeration value' in str(e.value)
+    assert e.value.subtype == prophy.CONSTRAINT_VIOLATION
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x00\x00\x01", ">")
     assert 'too few bytes to decode integer' in str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x00\x00\x00\x01\x01", ">")
     assert 'not all bytes of Enum read' in str(e.value)
+    assert e.value.subtype == prophy.TOO_MANY_BYTES
 
 
 def test_enum_exceptions():
@@ -119,17 +122,20 @@ def test_enum8_encoding(Enum8):
     x.decode(b"\x02", ">")
     assert x.value == 2
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x09", ">")
     assert 'unknown enumerator Enumeration8 value' in str(e.value)
+    assert e.value.subtype == prophy.CONSTRAINT_VIOLATION
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"", ">")
     assert 'too few bytes to decode integer' in str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x01\x01", ">")
     assert 'not all bytes of Enum8 read' in str(e.value)
+    assert e.value.subtype == prophy.TOO_MANY_BYTES
 
 
 def test_enum_with_overlapping_values():

--- a/prophy/tests/test_float.py
+++ b/prophy/tests/test_float.py
@@ -62,10 +62,12 @@ def test_float_codec(FloatTypeFactory, one, minus_one, too_long, too_short):
     x.value = -1.0
     assert x.encode(">") == minus_one
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(too_long, ">")
     assert "not all bytes of {} read".format(FloatTypeFactory.__name__) in str(e.value)
+    assert e.value.subtype == prophy.TOO_MANY_BYTES
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(too_short, ">")
     assert "too few bytes to decode integer" in str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES

--- a/prophy/tests/test_integers.py
+++ b/prophy/tests/test_integers.py
@@ -101,10 +101,12 @@ def test_integer_codec(IntType, a, encoded_a, b, encoded_b, too_short, too_long)
     x.decode(encoded_b, ">")
     assert x.value == b
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(too_short, ">")
     assert "too few bytes to decode integer" in str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
-    with pytest.raises(prophy.ProphyError) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(too_long, ">")
     assert "not all bytes of {} read".format(X.__name__) in str(e.value)
+    assert e.value.subtype == prophy.TOO_MANY_BYTES

--- a/prophy/tests/test_union.py
+++ b/prophy/tests/test_union.py
@@ -264,17 +264,20 @@ def test_union_discriminator_exceptions(VariableLengthFieldsUnion):
 def test_union_decode_exceptions(VariableLengthFieldsUnion):
     x = VariableLengthFieldsUnion()
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x00\x00\x00\xff", ">")
     assert "unknown discriminator" == str(e.value)
+    assert e.value.subtype == prophy.CONSTRAINT_VIOLATION
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x00\x00\x00\x02\x00\x00\x00\x00" b"\x12\x34\x56\x78\x00\x00\x00\x00\x00", ">")
     assert "not all bytes of VariableLengthFieldsUnion read" == str(e.value)
+    assert e.value.subtype == prophy.TOO_MANY_BYTES
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(prophy.DecodeError) as e:
         x.decode(b"\x00\x00\x00\x02\x00\x00\x00\x00" b"\x12\x34\x56\x78\x00\x00\x00", ">")
     assert "not enough bytes" == str(e.value)
+    assert e.value.subtype == prophy.NOT_ENOUGH_BYTES
 
 
 def test_struct_with_union():


### PR DESCRIPTION
As a result of discussion in #17, I'd like to introduce a new class for decoding-related errors -- `DecodeError(message, subtype)` which can convey extra field to distinguish well-known cases. It subclasses `ProphyError` so all existing client code will remain operational.

I've identified three exclusive classes of problems that can occur during the process of decoding payload:
- user hasn't provided enough data
- user provided too much data
- other `ProphyError` has occurred (for example while using slice assignments in the internal implementation or the array was longer than 65536 elements), I call this case a constraint violation

I defined consts for those cases in `exception.py`  (since `Enum` has been introduced in newer pythons and I think it's an overkill to write one or to add another dependency). They are used across the code wherever `DecodeError` is raised, passed as a second argument. They could have been defined as class attributes but that would require prefixing them with the name of error's class which in client code would look like this:
```python
prophy.DecodeError.CONSTRAINT_VIOLATION
```
vs. just
```python
prophy.CONSTRAINT_VIOLATION
```
I don't like the current solution too much either because it pollutes the namespace with the quite meaningless names. What do you think?

TODO:
- docs? There's nothing about exceptions that the library can raise at the moment. I think it could be done as a separate task since there are many types of problems that are represented by `ProphyError`
