### PR TITLE
ISAR's unicode bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ forthcoming
 1.2.1
 -----------------------------------
 - adopting to newer renew version: 0.4.1
+- fixing ISAR unicode bug introduced in 1.2.0
 
 1.2.0
 -----------------------------------

--- a/prophyc/parsers/isar.py
+++ b/prophyc/parsers/isar.py
@@ -194,6 +194,11 @@ class IsarParser(object):
         self.warn = warn
 
     def parse(self, content, _, process_file):
+        # by default FileProcessor decodes files while opening in _process_file method,
+        # but ElementTree doesn't like it. ElementTree handles the encoding on its own,
+        # so it's OK to encode the data back into utf-8 before parsing
+        content = content.encode('utf-8')
+
         def collect():
             root = ElementTree.fromstring(content)
             for xml_elem in root.iterfind('.//*[@href]'):

--- a/prophyc/tests/parsers/test_isar.py
+++ b/prophyc/tests/parsers/test_isar.py
@@ -1,9 +1,10 @@
+# -*- encoding: utf-8 -*-
 import pytest
 
 from prophyc import model
+from prophyc.file_processor import CyclicIncludeError, FileNotFoundError
 from prophyc.parsers.isar import IsarParser
 from prophyc.parsers.isar import expand_operators
-from prophyc.file_processor import CyclicIncludeError, FileNotFoundError
 
 
 def parse(xml_string, process_file=lambda path: [], warn=None):
@@ -572,3 +573,30 @@ def test_operator_expansion_in_enum_and_constant():
         ]))
     ]
     assert nodes[1].members[0].value == "((Constant) << (16))"
+
+
+def test_parsing_with_unicode_in_comment():
+    xml = u"""\
+<x>
+    <constant name="CONST_COMMENT" value="0" comment="it's …Jalapeño in comment"/>
+</x>
+"""
+    assert parse(xml) == [model.Constant('CONST_COMMENT', '0', u"it's …Jalapeño in comment")]
+
+
+def test_parsing_with_unicode_in_name():
+    xml = u"""\
+<x>
+    <constant name="CONST_NAME_Jalapeño" value="31"/>
+</x>
+"""
+    assert parse(xml) == [model.Constant(u'CONST_NAME_Jalapeño', '31')]
+
+
+def test_parsing_with_unicode_in_value():
+    xml = u"""\
+<x>
+    <constant name="CONST_VALUE" value="…ñ"/>
+</x>
+"""
+    assert parse(xml) == [model.Constant('CONST_VALUE', u'…ñ')]

--- a/prophyc/tests/test_prophyc_with_prophy.py
+++ b/prophyc/tests/test_prophyc_with_prophy.py
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+import codecs
 import os
 
 opd = os.path.dirname
@@ -10,10 +12,10 @@ def form_args(mode, tmpdir_cwd, target_file_name):
 
 
 def test_isar_input(tmpdir_cwd, call_prophyc):
-    content = """\
+    content = u"""\
 <dom>
     <constant name="MAX_NUM_OF_L2DEPLOYABLE_NODE" value="10"/>
-    <typedef name="TPoolId" type="u32"/>
+    <typedef name="TPoolId" type="u32" comment="it's …Jalapeño in comment"/>
     <typedef name="TNumberOfItems" primitiveType="32 bit integer unsigned"/>
     <enum name="EL2DeployableNode">
         <enum-member name="EL2DeployableNode_Basic1" value="0"/>
@@ -30,20 +32,21 @@ def test_isar_input(tmpdir_cwd, call_prophyc):
             variableSizeFieldComment="Currently either 4 or 8" variableSizeFieldName="numOfDeploymentInfo"/>
         </member>
     </struct>
-    <struct name="SL2DeploymentInfo">
+    <struct name="SL2DeploymentInfo" comment="it's …Jalapeño in comment">
         <member comment="Deployable node type" name="l2NodeType" type="EL2DeployableNode"/>
         <member comment="NID" name="nodeAddr" type="TAaSysComNid"/>
     </struct>
 </dom>
 """
 
-    xml_file_name = "isar.xml"
-    tmpdir_cwd.join(xml_file_name).write(content)
+    xml_file_name = "isar_test.xml"
+    with codecs.open(str(tmpdir_cwd.join(xml_file_name)), 'w', encoding='utf-8') as f:
+        f.write(content)
 
     call_prophyc(form_args("--isar", tmpdir_cwd, xml_file_name))
 
-    import isar
-    s = isar.SL2DeploymentInfo()
+    import isar_test
+    s = isar_test.SL2DeploymentInfo()
     s.l2NodeType = "EL2DeployableNode_Basic2"
     s.nodeAddr = 0x1231
 


### PR DESCRIPTION
Im' sorry. Unexpected thing happened.

I added possibility to open any source files encoded with `utf-8` in `prophy v 1.2.0` and it's nice (at least in my opinion), but I missed the fact that `xml.ElementTree` needs to get encoded strings and fails otherwise. 

The fix is very simple - just to encode the source back to raw `utf-8` before parsing by ISAR. Other parsers gets soft unicode strings. Thanks to that `FileProcessor` doesn't have to make any exceptions in encoding format regarding target parser (never did so far and still doesn't have to).
