### PR TITLE
Add parsing or expression

### DIFF
--- a/prophyc/calc.py
+++ b/prophyc/calc.py
@@ -80,7 +80,7 @@ class Calc(object):
         elif p[2] == '>>':
             p[0] = p[1] >> p[3]
         elif p[2] == '|':
-            p[0] = p[1] or p[3]
+            p[0] = p[1] | p[3]
 
     @staticmethod
     def p_expression_uminus(p):

--- a/prophyc/calc.py
+++ b/prophyc/calc.py
@@ -15,7 +15,7 @@ class Calc(object):
         ('right', 'UMINUS'),
     )
 
-    literals = ['+', '-', '*', '/', '(', ')']
+    literals = ['+', '-', '*', '/', '(', ')', '|']
 
     t_NAME = r'[a-zA-Z_][a-zA-Z0-9_]*'
     t_LSHIFT = r'<<'
@@ -64,6 +64,7 @@ class Calc(object):
                       | expression '-' expression
                       | expression '*' expression
                       | expression '/' expression
+                      | expression '|' expression
                       | expression LSHIFT expression
                       | expression RSHIFT expression"""
         if p[2] == '+':
@@ -78,6 +79,8 @@ class Calc(object):
             p[0] = p[1] << p[3]
         elif p[2] == '>>':
             p[0] = p[1] >> p[3]
+        elif p[2] == '|':
+            p[0] = p[1] or p[3]
 
     @staticmethod
     def p_expression_uminus(p):


### PR DESCRIPTION
Parsing '|' was not implemented. Now, expression like
((((EAaMemLteDspPoolCategory_Shared) << (16))) | (0)) 
is properly parsed and calculated.